### PR TITLE
docs: drop the GitHub Actions CI badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
   <a href="https://www.npmjs.com/package/@shadscan/cli"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/npm/dw/@shadscan/cli.svg?mode=dark"><img alt="npm weekly downloads" src="https://shieldcn.dev/npm/dw/@shadscan/cli.svg?mode=light"></picture></a>
   <a href="https://www.npmjs.com/package/@shadscan/cli"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/npm/node/@shadscan/cli.svg?mode=dark"><img alt="supported Node.js version" src="https://shieldcn.dev/npm/node/@shadscan/cli.svg?mode=light"></picture></a>
   <a href="packages/cli/LICENSE"><picture><source media="(prefers-color-scheme: dark)" srcset="https://shieldcn.dev/npm/license/@shadscan/cli.svg?mode=dark"><img alt="MIT license" src="https://shieldcn.dev/npm/license/@shadscan/cli.svg?mode=light"></picture></a>
-  <a href="https://github.com/TheOrcDev/shadscan/actions/workflows/quality.yml"><img alt="CI status" src="https://github.com/TheOrcDev/shadscan/actions/workflows/quality.yml/badge.svg"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Removes the GitHub Actions CI badge from the README badge row.

Every other badge in that row is rendered by [shieldcn](https://shieldcn.dev) in the shadcn style. The Actions badge used GitHub's own default styling, so it visually broke the row now that the repository is public and the badge actually renders.

No functional change — one line removed from `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the GitHub Actions CI status badge from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->