### PR TITLE
feat(site): add a contributors page

### DIFF
--- a/app/contributors/opengraph-image.tsx
+++ b/app/contributors/opengraph-image.tsx
@@ -1,0 +1,23 @@
+import { ImageResponse } from "next/og";
+import { SocialCard } from "@/components/social-card";
+
+const size = {
+  height: 630,
+  width: 1200,
+};
+
+const alt = "The people who build shadscan";
+const contentType = "image/png";
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    <SocialCard
+      detail="Every rule ships because someone sent a pull request."
+      footer="Built in the open. Join the contributors."
+      headline="The people behind shadscan."
+    />,
+    size
+  );
+}
+
+export { alt, contentType, size };

--- a/app/contributors/page.tsx
+++ b/app/contributors/page.tsx
@@ -1,0 +1,211 @@
+import { ArrowSquareOutIcon } from "@phosphor-icons/react/dist/ssr";
+import Image from "next/image";
+import { ShadscanMark } from "@/components/shadscan-mark";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import {
+  type Contributor,
+  getContributorStats,
+  getContributors,
+  resolveContributorsRepository,
+} from "@/lib/contributors";
+import { createPageMetadata } from "@/lib/site-metadata";
+
+const AVATAR_SIZE_PX = 48;
+
+// Contributors come from the GitHub API, so the page refreshes hourly on its
+// own instead of waiting for a redeploy. Segment config must be a literal.
+export const revalidate = 3600;
+
+export const metadata = createPageMetadata({
+  description:
+    "Meet the people who build shadscan, the deterministic UI audit CLI for React and shadcn applications.",
+  imageAlt: "The people who build shadscan",
+  imagePath: "/contributors/opengraph-image",
+  path: "/contributors",
+  title: "Shadscan contributors",
+});
+
+const numberFormatter = new Intl.NumberFormat("en-US");
+
+interface StatProps {
+  label: string;
+  value: number;
+}
+
+function Stat({ label, value }: StatProps) {
+  return (
+    <div className="border border-border p-6 text-center">
+      <dt className="font-mono font-semibold text-muted-foreground text-xs uppercase">
+        {label}
+      </dt>
+      <dd className="mt-2 font-heading font-medium text-4xl tabular-nums">
+        {numberFormatter.format(value)}
+      </dd>
+    </div>
+  );
+}
+
+interface ContributorCardProps {
+  contributor: Contributor;
+  rank: number;
+}
+
+function ContributorCard({ contributor, rank }: ContributorCardProps) {
+  const { avatarUrl, contributions, login, profileUrl } = contributor;
+  const contributionLabel = contributions === 1 ? "commit" : "commits";
+
+  return (
+    <a
+      className="group flex h-full w-full items-center gap-4 border border-border p-4 transition-colors hover:border-foreground/40 hover:bg-muted/40"
+      href={profileUrl}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <span className="font-mono text-muted-foreground text-xs tabular-nums">
+        {String(rank).padStart(2, "0")}
+      </span>
+      <Image
+        alt=""
+        className="shrink-0 border border-border"
+        height={AVATAR_SIZE_PX}
+        src={avatarUrl}
+        // GitHub already serves correctly sized avatars from its own CDN.
+        unoptimized
+        width={AVATAR_SIZE_PX}
+      />
+      <span className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="truncate font-heading font-medium group-hover:underline group-hover:underline-offset-4">
+          {login}
+        </span>
+        <span>
+          <Badge variant="secondary">
+            {numberFormatter.format(contributions)} {contributionLabel}
+          </Badge>
+        </span>
+      </span>
+      <ArrowSquareOutIcon
+        aria-hidden="true"
+        className="shrink-0 text-muted-foreground transition-colors group-hover:text-foreground"
+      />
+      <span className="sr-only">
+        {`${login} on GitHub, ${numberFormatter.format(contributions)} ${contributionLabel}`}
+      </span>
+    </a>
+  );
+}
+
+export default async function ContributorsPage() {
+  const repository = resolveContributorsRepository();
+  const contributors = await getContributors();
+  const { totalContributions, totalContributors } =
+    getContributorStats(contributors);
+  const repositoryUrl = `https://github.com/${repository}`;
+
+  return (
+    <main className="flex-1 overflow-x-clip bg-background text-foreground">
+      <div className="mx-auto w-full max-w-4xl px-4 pt-12 pb-24 sm:px-6 sm:pt-16">
+        <header className="flex flex-col items-center gap-4 pb-12 text-center">
+          <ShadscanMark
+            accessibleTitle="shadscan"
+            className="size-16 text-foreground"
+          />
+          <h1 className="font-heading font-medium text-4xl">Contributors</h1>
+          <p className="max-w-xl text-balance text-muted-foreground">
+            shadscan is built in the open. Every rule, every fix, and every
+            audit it runs exists because someone sent a pull request. These are
+            the people behind them.
+          </p>
+        </header>
+
+        <div className="flex flex-col gap-12">
+          {contributors.length > 0 ? (
+            <section aria-label="Contribution totals">
+              <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <Stat label="Contributors" value={totalContributors} />
+                <Stat label="Commits" value={totalContributions} />
+              </dl>
+            </section>
+          ) : null}
+
+          <section aria-label="Contributor list">
+            <div className="flex flex-col gap-3">
+              <div className="flex items-baseline justify-between gap-3">
+                <h2 className="font-mono font-semibold text-muted-foreground text-xs uppercase">
+                  Everyone who shipped
+                </h2>
+                <p className="font-mono font-semibold text-foreground text-xs">
+                  {repository}
+                </p>
+              </div>
+              <Separator />
+            </div>
+
+            {contributors.length > 0 ? (
+              <ul className="grid gap-3 pt-4 sm:grid-cols-2">
+                {contributors.map((contributor, index) => (
+                  <li className="flex min-w-0" key={contributor.login}>
+                    <ContributorCard
+                      contributor={contributor}
+                      rank={index + 1}
+                    />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="mt-4 border border-border border-dashed p-8 text-center">
+                <p className="text-muted-foreground">
+                  The contributor list is unavailable right now. GitHub caches
+                  it hourly, so check back soon or open the repository directly.
+                </p>
+              </div>
+            )}
+          </section>
+
+          <section aria-label="How to contribute">
+            <div className="flex flex-col gap-3">
+              <div className="flex items-baseline justify-between gap-3">
+                <h2 className="font-mono font-semibold text-muted-foreground text-xs uppercase">
+                  Join them
+                </h2>
+                <p className="font-mono font-semibold text-foreground text-xs">
+                  Open source
+                </p>
+              </div>
+              <Separator />
+            </div>
+            <div className="mt-4 border border-border p-8 text-center">
+              <p className="mx-auto max-w-md text-muted-foreground">
+                Rules are deterministic and every one ships with tests, so a
+                first contribution can be as small as a single new check. Pick
+                an issue, or open one describing the check you wish shadscan
+                ran.
+              </p>
+              <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+                <Button asChild>
+                  <a
+                    href={repositoryUrl}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    View the repository
+                  </a>
+                </Button>
+                <Button asChild variant="outline">
+                  <a
+                    href={`${repositoryUrl}/issues`}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Browse open issues
+                  </a>
+                </Button>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -36,6 +36,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: new URL("/sponsors", siteUrl).href,
     },
     {
+      changeFrequency: "weekly",
+      priority: 0.5,
+      url: new URL("/contributors", siteUrl).href,
+    },
+    {
       changeFrequency: "yearly",
       priority: 0.2,
       url: new URL("/privacy", siteUrl).href,

--- a/components/command-menu.tsx
+++ b/components/command-menu.tsx
@@ -9,6 +9,7 @@ import {
   ListChecks,
   MagnifyingGlass,
   Sparkle,
+  UsersThree,
 } from "@phosphor-icons/react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -179,6 +180,15 @@ function CommandMenu({ repositoryUrl }: CommandMenuProps) {
               >
                 <ClockCounterClockwise weight="bold" />
                 Changelog
+              </CommandItem>
+              <CommandItem
+                onSelect={() => {
+                  setOpen(false);
+                  router.push("/contributors");
+                }}
+              >
+                <UsersThree weight="bold" />
+                Contributors
               </CommandItem>
             </CommandGroup>
             <CommandGroup heading="CLI">

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -16,7 +16,13 @@ function SiteFooter() {
           </a>{" "}
           with <span aria-hidden="true">🪓</span>
         </p>
-        <nav aria-label="Legal" className="flex items-center gap-4 text-sm">
+        <nav aria-label="Secondary" className="flex items-center gap-4 text-sm">
+          <Link
+            className="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+            href="/contributors"
+          >
+            Contributors
+          </Link>
           <Link
             className="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
             href="/privacy"

--- a/lib/contributors.ts
+++ b/lib/contributors.ts
@@ -1,0 +1,199 @@
+import { unstable_cache } from "next/cache";
+import type { FetchImplementation } from "@/lib/public-github-repository";
+import {
+  getConfiguredGitHubRepository,
+  SOURCE_CODE_GITHUB_REPOSITORY,
+} from "@/lib/public-github-repository";
+
+const GITHUB_API_ORIGIN = "https://api.github.com";
+const GITHUB_AVATAR_HOST = "avatars.githubusercontent.com";
+const GITHUB_AVATAR_PATH_PREFIX = "/u/";
+// Twice the rendered avatar size, so retina screens stay sharp without pulling
+// full-resolution avatars for every contributor.
+const AVATAR_REQUEST_SIZE_PX = 96;
+const GITHUB_PROFILE_HOST = "github.com";
+const CONTRIBUTORS_PER_PAGE = 100;
+const REVALIDATE_SECONDS = 3600;
+const REQUEST_TIMEOUT_MS = 3000;
+// GitHub reports automation accounts alongside people; this page is about people.
+const BOT_ACCOUNT_TYPE = "Bot";
+
+interface Contributor {
+  avatarUrl: string;
+  contributions: number;
+  login: string;
+  profileUrl: string;
+}
+
+interface ContributorStats {
+  totalContributions: number;
+  totalContributors: number;
+}
+
+interface ContributorsEnvironment {
+  GITHUB_TOKEN?: string;
+  SHADSCAN_PUBLIC_GITHUB_REPOSITORY?: string;
+  readonly [key: string]: string | undefined;
+}
+
+const isHttpsUrl = (
+  value: string,
+  host: string,
+  pathPrefix: string
+): boolean => {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      url.host === host &&
+      url.pathname.startsWith(pathPrefix)
+    );
+  } catch {
+    return false;
+  }
+};
+
+const toAvatarUrl = (value: string): string => {
+  const avatarUrl = new URL(value);
+  avatarUrl.searchParams.set("s", String(AVATAR_REQUEST_SIZE_PX));
+  return avatarUrl.href;
+};
+
+/**
+ * Keeps unexpected GitHub payloads from reaching the page as broken cards, and
+ * keeps avatars and profile links pointed at GitHub.
+ */
+const toContributor = (entry: unknown): Contributor | null => {
+  if (typeof entry !== "object" || entry === null) {
+    return null;
+  }
+
+  const {
+    avatar_url: avatarUrl,
+    contributions,
+    html_url: profileUrl,
+    login,
+    type,
+  } = entry as Record<string, unknown>;
+
+  if (
+    typeof login !== "string" ||
+    typeof avatarUrl !== "string" ||
+    typeof profileUrl !== "string" ||
+    typeof contributions !== "number"
+  ) {
+    return null;
+  }
+
+  if (
+    login.length === 0 ||
+    !Number.isSafeInteger(contributions) ||
+    contributions <= 0 ||
+    type === BOT_ACCOUNT_TYPE ||
+    !isHttpsUrl(avatarUrl, GITHUB_AVATAR_HOST, GITHUB_AVATAR_PATH_PREFIX) ||
+    !isHttpsUrl(profileUrl, GITHUB_PROFILE_HOST, `/${login}`)
+  ) {
+    return null;
+  }
+
+  return {
+    avatarUrl: toAvatarUrl(avatarUrl),
+    contributions,
+    login,
+    profileUrl,
+  };
+};
+
+const byContributionsThenLogin = (
+  first: Contributor,
+  second: Contributor
+): number =>
+  second.contributions - first.contributions ||
+  first.login.localeCompare(second.login);
+
+const fetchGitHubContributors = async (
+  repository: string,
+  fetchImplementation: FetchImplementation = fetch,
+  environment: ContributorsEnvironment = process.env
+): Promise<Contributor[]> => {
+  try {
+    const headers = new Headers({
+      Accept: "application/vnd.github+json",
+      "User-Agent": "shadscan",
+      "X-GitHub-Api-Version": "2022-11-28",
+    });
+    const token = environment.GITHUB_TOKEN;
+    if (token) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+
+    const response = await fetchImplementation(
+      `${GITHUB_API_ORIGIN}/repos/${repository}/contributors?per_page=${CONTRIBUTORS_PER_PAGE}`,
+      {
+        headers,
+        redirect: "error",
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      }
+    );
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const payload: unknown = await response.json();
+    if (!Array.isArray(payload)) {
+      return [];
+    }
+
+    const contributors: Contributor[] = [];
+    for (const entry of payload) {
+      const contributor = toContributor(entry);
+      if (contributor !== null) {
+        contributors.push(contributor);
+      }
+    }
+
+    return contributors.sort(byContributionsThenLogin);
+  } catch {
+    return [];
+  }
+};
+
+const getCachedGitHubContributors = unstable_cache(
+  fetchGitHubContributors,
+  ["github-contributors"],
+  { revalidate: REVALIDATE_SECONDS }
+);
+
+const resolveContributorsRepository = (
+  environment: ContributorsEnvironment = process.env
+): string =>
+  getConfiguredGitHubRepository(environment) ?? SOURCE_CODE_GITHUB_REPOSITORY;
+
+/**
+ * Contributors for the source repository. Resolves to an empty list whenever
+ * GitHub is unreachable or the repository is still private, so the page always
+ * renders.
+ */
+const getContributors = (
+  environment: ContributorsEnvironment = process.env
+): Promise<Contributor[]> =>
+  getCachedGitHubContributors(resolveContributorsRepository(environment));
+
+const getContributorStats = (
+  contributors: readonly Contributor[]
+): ContributorStats => ({
+  totalContributions: contributors.reduce(
+    (total, contributor) => total + contributor.contributions,
+    0
+  ),
+  totalContributors: contributors.length,
+});
+
+export type { Contributor, ContributorStats };
+export {
+  fetchGitHubContributors,
+  getContributorStats,
+  getContributors,
+  resolveContributorsRepository,
+};

--- a/test/e2e/contributors-page.spec.ts
+++ b/test/e2e/contributors-page.spec.ts
@@ -1,0 +1,175 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect } from "@playwright/test";
+import type { FetchHandlerResult } from "next/experimental/testmode/playwright.js";
+import { test } from "next/experimental/testmode/playwright.js";
+
+const REPOSITORY = "TheOrcDev/shadscan";
+const REPOSITORY_URL = `https://api.github.com/repos/${REPOSITORY}`;
+const CONTRIBUTORS_URL = `${REPOSITORY_URL}/contributors?per_page=100`;
+
+const TOP_CONTRIBUTOR_LABEL = /TheOrcDev on GitHub, 128 commits/;
+const SINGLE_COMMIT_LABEL = /grommash on GitHub, 1 commit$/;
+const CONTRIBUTORS_PATH = /\/contributors$/;
+
+const VIEWPORTS = [
+  { height: 820, width: 320 },
+  { height: 820, width: 375 },
+  { height: 900, width: 768 },
+  { height: 1000, width: 1440 },
+] as const;
+
+const CONTRIBUTORS = [
+  {
+    avatar_url: "https://avatars.githubusercontent.com/u/1?v=4",
+    contributions: 128,
+    html_url: "https://github.com/TheOrcDev",
+    login: "TheOrcDev",
+    type: "User",
+  },
+  {
+    avatar_url: "https://avatars.githubusercontent.com/u/2?v=4",
+    contributions: 1,
+    html_url: "https://github.com/grommash",
+    login: "grommash",
+    type: "User",
+  },
+  {
+    avatar_url: "https://avatars.githubusercontent.com/u/3?v=4",
+    contributions: 9,
+    html_url: "https://github.com/dependabot",
+    login: "dependabot",
+    type: "Bot",
+  },
+] as const;
+
+const createGitHubHandler =
+  (contributorsResponse: () => FetchHandlerResult) =>
+  (request: Request): FetchHandlerResult => {
+    if (request.url === CONTRIBUTORS_URL) {
+      return contributorsResponse();
+    }
+
+    if (request.url === REPOSITORY_URL) {
+      return Response.json({ private: false, stargazers_count: 128 });
+    }
+
+    return "abort";
+  };
+
+test("lists every human contributor with their commit counts", async ({
+  next,
+  page,
+}) => {
+  next.onFetch(createGitHubHandler(() => Response.json(CONTRIBUTORS)));
+
+  await page.goto("/contributors");
+
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Contributors" })
+  ).toBeVisible();
+
+  const totals = page.getByRole("region", { name: "Contribution totals" });
+  await expect(totals.getByText("2", { exact: true })).toBeVisible();
+  await expect(totals.getByText("129", { exact: true })).toBeVisible();
+
+  const list = page.getByRole("region", { name: "Contributor list" });
+  const contributorLinks = list.getByRole("link");
+  await expect(contributorLinks).toHaveCount(2);
+
+  // Ranked by commits, and the bot account never renders.
+  await expect(contributorLinks.first()).toHaveAttribute(
+    "href",
+    "https://github.com/TheOrcDev"
+  );
+  await expect(
+    list.getByRole("link", { name: TOP_CONTRIBUTOR_LABEL })
+  ).toBeVisible();
+  await expect(
+    list.getByRole("link", { name: SINGLE_COMMIT_LABEL })
+  ).toBeVisible();
+  await expect(list.getByText("dependabot")).toHaveCount(0);
+
+  const contributeSection = page.getByRole("region", {
+    name: "How to contribute",
+  });
+  await expect(
+    contributeSection.getByRole("link", { name: "View the repository" })
+  ).toHaveAttribute("href", `https://github.com/${REPOSITORY}`);
+  await expect(
+    contributeSection.getByRole("link", { name: "Browse open issues" })
+  ).toHaveAttribute("href", `https://github.com/${REPOSITORY}/issues`);
+
+  const results = await new AxeBuilder({ page }).analyze();
+  const severeViolations = results.violations.filter(
+    ({ impact }) => impact === "serious" || impact === "critical"
+  );
+  expect(severeViolations, JSON.stringify(severeViolations, null, 2)).toEqual(
+    []
+  );
+});
+
+test("stays useful when GitHub cannot serve the contributor list", async ({
+  next,
+  page,
+}) => {
+  next.onFetch(createGitHubHandler(() => new Response(null, { status: 404 })));
+
+  await page.goto("/contributors");
+
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Contributors" })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("region", { name: "Contribution totals" })
+  ).toHaveCount(0);
+  await expect(
+    page.getByText("The contributor list is unavailable right now.")
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "View the repository" })
+  ).toBeVisible();
+
+  const results = await new AxeBuilder({ page }).analyze();
+  const severeViolations = results.violations.filter(
+    ({ impact }) => impact === "serious" || impact === "critical"
+  );
+  expect(severeViolations, JSON.stringify(severeViolations, null, 2)).toEqual(
+    []
+  );
+});
+
+test("links to the contributors page from the site footer", async ({
+  next,
+  page,
+}) => {
+  next.onFetch(createGitHubHandler(() => Response.json(CONTRIBUTORS)));
+
+  await page.goto("/");
+  await page
+    .getByRole("navigation", { name: "Secondary" })
+    .getByRole("link", { name: "Contributors" })
+    .click();
+
+  await expect(page).toHaveURL(CONTRIBUTORS_PATH);
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Contributors" })
+  ).toBeVisible();
+});
+
+for (const viewport of VIEWPORTS) {
+  test(`fits the contributors page at ${viewport.width}px`, async ({
+    next,
+    page,
+  }) => {
+    next.onFetch(createGitHubHandler(() => Response.json(CONTRIBUTORS)));
+
+    await page.setViewportSize(viewport);
+    await page.goto("/contributors");
+
+    const dimensions = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+  });
+}

--- a/test/e2e/legal-pages.spec.ts
+++ b/test/e2e/legal-pages.spec.ts
@@ -46,13 +46,18 @@ for (const legalPage of LEGAL_PAGES) {
       page.getByRole("link", { name: "orc@orcdev.com" })
     ).toHaveAttribute("href", "mailto:orc@orcdev.com");
 
-    const legalNavigation = page.getByRole("navigation", { name: "Legal" });
+    const footerNavigation = page.getByRole("navigation", {
+      name: "Secondary",
+    });
     await expect(
-      legalNavigation.getByRole("link", { name: "Privacy" })
+      footerNavigation.getByRole("link", { name: "Privacy" })
     ).toHaveAttribute("href", "/privacy");
     await expect(
-      legalNavigation.getByRole("link", { name: "Terms" })
+      footerNavigation.getByRole("link", { name: "Terms" })
     ).toHaveAttribute("href", "/terms");
+    await expect(
+      footerNavigation.getByRole("link", { name: "Contributors" })
+    ).toHaveAttribute("href", "/contributors");
 
     const results = await new AxeBuilder({ page }).analyze();
     const severeViolations = results.violations.filter(

--- a/test/e2e/metadata.spec.ts
+++ b/test/e2e/metadata.spec.ts
@@ -46,6 +46,14 @@ const PAGE_METADATA = [
     socialTitle: "Sponsor shadscan | shadscan",
   },
   {
+    browserTitle: "Shadscan contributors | shadscan",
+    description:
+      "Meet the people who build shadscan, the deterministic UI audit CLI for React and shadcn applications.",
+    imagePath: "/contributors/opengraph-image",
+    path: "/contributors",
+    socialTitle: "Shadscan contributors | shadscan",
+  },
+  {
     browserTitle: "Privacy Policy | shadscan",
     description:
       "How Shadscan processes repository scans, request data, local preferences, and communications.",
@@ -253,6 +261,7 @@ for (const imagePath of [
   "/scan/opengraph-image",
   "/docs/opengraph-image",
   "/sponsors/opengraph-image",
+  "/contributors/opengraph-image",
 ]) {
   test(`renders the 1200x630 social card at ${imagePath}`, async ({
     request,

--- a/test/shadscan-web/contributors.test.ts
+++ b/test/shadscan-web/contributors.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type Contributor,
+  fetchGitHubContributors,
+  getContributorStats,
+  resolveContributorsRepository,
+} from "@/lib/contributors";
+import type { FetchImplementation } from "@/lib/public-github-repository";
+import { SOURCE_CODE_GITHUB_REPOSITORY } from "@/lib/public-github-repository";
+
+const REPOSITORY = "TheOrcDev/shadscan";
+const CONTRIBUTORS_URL = `https://api.github.com/repos/${REPOSITORY}/contributors?per_page=100`;
+
+const createApiContributor = (overrides: Record<string, unknown> = {}) => ({
+  avatar_url: "https://avatars.githubusercontent.com/u/1?v=4",
+  contributions: 12,
+  html_url: "https://github.com/orcdev",
+  login: "orcdev",
+  type: "User",
+  ...overrides,
+});
+
+const respondWith =
+  (payload: unknown): FetchImplementation =>
+  () =>
+    Promise.resolve(Response.json(payload));
+
+describe("contributors repository resolution", () => {
+  it("falls back to the source repository when none is configured", () => {
+    expect(resolveContributorsRepository({})).toBe(
+      SOURCE_CODE_GITHUB_REPOSITORY
+    );
+  });
+
+  it("uses the configured public repository", () => {
+    expect(
+      resolveContributorsRepository({
+        SHADSCAN_PUBLIC_GITHUB_REPOSITORY: "shadcn-ui/next-template",
+      })
+    ).toBe("shadcn-ui/next-template");
+  });
+});
+
+describe("contributor fetching", () => {
+  it("requests the contributor list without a token by default", async () => {
+    const fetchImplementation = vi.fn(respondWith([createApiContributor()]));
+
+    await expect(
+      fetchGitHubContributors(REPOSITORY, fetchImplementation, {})
+    ).resolves.toEqual([
+      {
+        avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4&s=96",
+        contributions: 12,
+        login: "orcdev",
+        profileUrl: "https://github.com/orcdev",
+      },
+    ]);
+
+    expect(fetchImplementation).toHaveBeenCalledOnce();
+    const [url, init] = fetchImplementation.mock.calls[0] ?? [];
+    expect(url).toBe(CONTRIBUTORS_URL);
+    expect(init?.redirect).toBe("error");
+    expect(new Headers(init?.headers).has("authorization")).toBe(false);
+  });
+
+  it("authorizes the request when a token is configured", async () => {
+    const fetchImplementation = vi.fn(respondWith([]));
+
+    await fetchGitHubContributors(REPOSITORY, fetchImplementation, {
+      GITHUB_TOKEN: "token-value",
+    });
+
+    const [, init] = fetchImplementation.mock.calls[0] ?? [];
+    expect(new Headers(init?.headers).get("authorization")).toBe(
+      "Bearer token-value"
+    );
+  });
+
+  it("requests avatars at the rendered size", async () => {
+    const [contributor] = await fetchGitHubContributors(
+      REPOSITORY,
+      respondWith([
+        createApiContributor({
+          avatar_url: "https://avatars.githubusercontent.com/u/7?v=4&s=460",
+        }),
+      ]),
+      {}
+    );
+
+    expect(contributor?.avatarUrl).toBe(
+      "https://avatars.githubusercontent.com/u/7?v=4&s=96"
+    );
+  });
+
+  it("ranks contributors by contributions, then login", async () => {
+    const contributors = await fetchGitHubContributors(
+      REPOSITORY,
+      respondWith([
+        createApiContributor({
+          contributions: 3,
+          html_url: "https://github.com/zara",
+          login: "zara",
+        }),
+        createApiContributor({
+          contributions: 9,
+          html_url: "https://github.com/thrall",
+          login: "thrall",
+        }),
+        createApiContributor({
+          contributions: 3,
+          html_url: "https://github.com/anduin",
+          login: "anduin",
+        }),
+      ]),
+      {}
+    );
+
+    expect(contributors.map(({ login }) => login)).toEqual([
+      "thrall",
+      "anduin",
+      "zara",
+    ]);
+  });
+
+  it.each([
+    ["a bot account", createApiContributor({ type: "Bot" })],
+    ["a zero-contribution entry", createApiContributor({ contributions: 0 })],
+    [
+      "a non-numeric contribution count",
+      createApiContributor({ contributions: "12" }),
+    ],
+    [
+      "an off-host avatar",
+      createApiContributor({ avatar_url: "https://example.com/u/1.png" }),
+    ],
+    [
+      "an unoptimizable avatar path",
+      createApiContributor({
+        avatar_url: "https://avatars.githubusercontent.com/in/1?v=4",
+      }),
+    ],
+    [
+      "an off-host profile link",
+      createApiContributor({ html_url: "https://example.com/orcdev" }),
+    ],
+    [
+      "a profile link for another account",
+      createApiContributor({ html_url: "https://github.com/someone-else" }),
+    ],
+    ["a malformed entry", { login: "orcdev" }],
+    ["a non-object entry", "orcdev"],
+  ])("drops %s", async (_name, entry) => {
+    await expect(
+      fetchGitHubContributors(REPOSITORY, respondWith([entry]), {})
+    ).resolves.toEqual([]);
+  });
+
+  it.each([
+    ["an error response", new Response(null, { status: 404 })],
+    ["a non-array payload", Response.json({ message: "Not Found" })],
+  ])("returns an empty list for %s", async (_name, response) => {
+    await expect(
+      fetchGitHubContributors(REPOSITORY, () => Promise.resolve(response), {})
+    ).resolves.toEqual([]);
+  });
+
+  it("returns an empty list when GitHub cannot be reached", async () => {
+    await expect(
+      fetchGitHubContributors(
+        REPOSITORY,
+        () => Promise.reject(new Error("network unreachable")),
+        {}
+      )
+    ).resolves.toEqual([]);
+  });
+});
+
+describe("contributor stats", () => {
+  it("totals contributors and their contributions", () => {
+    const contributors: Contributor[] = [
+      {
+        avatarUrl: "https://avatars.githubusercontent.com/u/1?v=4&s=96",
+        contributions: 40,
+        login: "thrall",
+        profileUrl: "https://github.com/thrall",
+      },
+      {
+        avatarUrl: "https://avatars.githubusercontent.com/u/2?v=4",
+        contributions: 2,
+        login: "zara",
+        profileUrl: "https://github.com/zara",
+      },
+    ];
+
+    expect(getContributorStats(contributors)).toEqual({
+      totalContributions: 42,
+      totalContributors: 2,
+    });
+  });
+
+  it("reports zeroes for an empty list", () => {
+    expect(getContributorStats([])).toEqual({
+      totalContributions: 0,
+      totalContributors: 0,
+    });
+  });
+});


### PR DESCRIPTION
Adds `/contributors`, crediting the people behind shadscan. Same idea as the videorc contributors page, rebuilt in shadscan's own visual language: square borders, mono uppercase section labels, `Separator` rules, `Badge` counts, and the `ShadscanMark` header used on `/sponsors`.

## What's here

- **`lib/contributors.ts`** — follows the `public-github-repository.ts` conventions: bounded timeout, `redirect: "error"`, hourly `unstable_cache`, injectable fetch for tests. Every payload field is validated, bot accounts are dropped, avatars and profile links must point at GitHub, and avatars are requested at `s=96` straight from GitHub's CDN instead of being proxied through the image optimizer. Any failure resolves to an empty list rather than throwing.
- **`app/contributors/page.tsx`** — totals, a ranked grid, and a contribute CTA. Repository resolution reuses `SHADSCAN_PUBLIC_GITHUB_REPOSITORY` with the same source-repo fallback as the header, so the page needs no new configuration.
- **Degraded state** — the repo is private today, so GitHub returns 404 and the page ships the empty state with the CTA still useful. It fills in on its own once the repo goes public; no redeploy needed.
- **Discovery** — footer link, command menu entry, sitemap, and its own social card. The header nav is left alone; a fourth item overflows at 320px.

The footer nav is relabelled from `Legal` to `Secondary` now that it carries a non-legal link.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm check` | clean |
| `pnpm ci:typecheck` | clean |
| `pnpm ci:test-web` | 152 passed (20 new) |
| `pnpm ci:test-e2e` | 58 passed (7 new) |
| `pnpm ci:build-site` | `/contributors` prerendered, 1h revalidate |
| `pnpm ci:audit-self` | 100/100 (Grade A) |

New e2e coverage asserts ranking, bot exclusion, commit-count labels, the empty state, the footer link, an axe pass with no serious or critical violations, and no horizontal overflow at 320/375/768/1440.

Checked visually in light, dark, and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Contributors page showing contributor profiles, rankings, avatars, and contribution totals.
  * Added contributor navigation through the command menu, site footer, and sitemap.
  * Added a social sharing image for the Contributors page.
  * Added a “How to contribute” section with repository and issue links.

* **Tests**
  * Added coverage for contributor data, page rendering, metadata, navigation, accessibility, and responsive layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->