### PR TITLE
feat(site): stack the supporting label above the framework marks

### DIFF
--- a/components/supported-frameworks.tsx
+++ b/components/supported-frameworks.tsx
@@ -16,14 +16,9 @@ interface SupportedFrameworksProps {
 function SupportedFrameworks({ className }: SupportedFrameworksProps) {
   return (
     <TooltipProvider>
-      <div
-        className={cn(
-          "flex flex-wrap items-center justify-center gap-x-4 gap-y-2",
-          className
-        )}
-      >
+      <div className={cn("flex flex-col items-center gap-3", className)}>
         <span className="font-mono text-muted-foreground text-xs uppercase tracking-wide">
-          Supporting:
+          Supporting
         </span>
         <ul className="flex items-center gap-4">
           {FRAMEWORK_MARKS.map((mark) => (


### PR DESCRIPTION
Follow-up to #11, which was merged just before this commit landed on the branch: moves "Supporting" onto its own line above the icon row and drops the colon, so the label reads as a heading for the marks rather than an inline prefix.

Verified in the preview before the original push (label centered above the row, tooltip behavior unchanged) and covered by the same green gates: check, typecheck, 58 e2e tests, shadscan self-audit 100/100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Supporting” section to the hero area showcasing supported frameworks.
  * Added framework logos for Next.js, Vite, TanStack Start, and Laravel.
  * Added accessible tooltips displaying each framework’s name on hover or keyboard focus.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->