### PR TITLE
fix(site): square the /stats page to match the shadcn preset

### DIFF
--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -37,7 +37,7 @@ interface StatTileProps {
 
 function StatTile({ detail, label, title, value }: StatTileProps) {
   return (
-    <div className="flex flex-col gap-1 rounded-lg border border-border p-4">
+    <div className="flex flex-col gap-1 rounded-none border border-border p-4">
       <dt className="text-muted-foreground text-sm">{label}</dt>
       <dd
         className="font-heading font-semibold text-2xl tabular-nums"
@@ -54,7 +54,7 @@ function StatTile({ detail, label, title, value }: StatTileProps) {
 
 function StatsUnavailable() {
   return (
-    <p className="rounded-lg border border-border border-dashed p-6 text-muted-foreground text-sm">
+    <p className="rounded-none border border-border border-dashed p-6 text-muted-foreground text-sm">
       Download stats are temporarily unavailable. The npm registry did not
       answer; this page will fill back in on its next refresh.
     </p>
@@ -77,7 +77,7 @@ export default async function StatsPage() {
         </h1>
         <p className="max-w-2xl text-muted-foreground">
           Public usage numbers for{" "}
-          <code className="rounded bg-muted px-1.5 py-0.5 text-sm">
+          <code className="rounded-none bg-muted px-1.5 py-0.5 text-sm">
             {PACKAGE_NAME}
           </code>
           , pulled from the npm registry. Counts include continuous integration

--- a/components/charts/tooltip/date-ticker.tsx
+++ b/components/charts/tooltip/date-ticker.tsx
@@ -20,7 +20,7 @@ const DateTickerCompact = memo(function DateTickerCompact({
   const label = labels[currentIndex] ?? labels[0] ?? "";
 
   return (
-    <div className="overflow-hidden rounded-full bg-zinc-900 px-4 py-1 text-white shadow-lg dark:bg-zinc-100 dark:text-zinc-900">
+    <div className="overflow-hidden rounded-none bg-zinc-900 px-4 py-1 text-white shadow-lg dark:bg-zinc-100 dark:text-zinc-900">
       <div className="flex h-6 items-center justify-center">
         <span className="whitespace-nowrap font-medium text-sm">{label}</span>
       </div>
@@ -95,7 +95,7 @@ const DateTickerInner = memo(function DateTickerInner({
   }
 
   return (
-    <div className="overflow-hidden rounded-full bg-zinc-900 px-4 py-1 text-white shadow-lg dark:bg-zinc-100 dark:text-zinc-900">
+    <div className="overflow-hidden rounded-none bg-zinc-900 px-4 py-1 text-white shadow-lg dark:bg-zinc-100 dark:text-zinc-900">
       <div className="relative h-6 overflow-hidden">
         <div className="flex items-center justify-center gap-1">
           {/* Month stack */}

--- a/components/charts/tooltip/tooltip-box.tsx
+++ b/components/charts/tooltip/tooltip-box.tsx
@@ -176,7 +176,7 @@ function TooltipBoxInner({
   const transformOrigin = isFlipped ? "right top" : "left top";
 
   const panelClassName = cn(
-    "min-w-[140px] overflow-hidden rounded-lg text-chart-tooltip-foreground shadow-lg",
+    "min-w-[140px] overflow-hidden rounded-none text-chart-tooltip-foreground shadow-lg",
     panelStyle?.backgroundColor === undefined &&
       backgroundColor === chartCssVars.tooltipBackground &&
       "bg-chart-tooltip-background",

--- a/components/charts/tooltip/tooltip-content.tsx
+++ b/components/charts/tooltip/tooltip-content.tsx
@@ -33,7 +33,7 @@ export function TooltipContent({ title, rows, children }: TooltipContentProps) {
             >
               <div className="flex items-center gap-2">
                 <span
-                  className="h-2.5 w-2.5 shrink-0 rounded-full"
+                  className="h-2.5 w-2.5 shrink-0 rounded-none"
                   style={{ backgroundColor: row.color }}
                 />
                 <span className="text-chart-tooltip-muted text-sm">

--- a/components/stats-charts.tsx
+++ b/components/stats-charts.tsx
@@ -21,6 +21,19 @@ import type { DownloadDay, VersionDownloads } from "@/lib/npm-stats";
  */
 const SERIES_COLOR = "var(--stats-series)";
 
+/**
+ * The chart primitives default to rounded marks — bars get an 8px cap and the
+ * hover marker is a circle. This site's shadcn preset (`radix-sera`) is squared
+ * everywhere, so the mark geometry is squared here, at the call site, using the
+ * primitives' own props. The tooltip's own chrome has no such props and is
+ * squared in `components/charts/tooltip` instead.
+ */
+const SQUARE_BAR_CAP = "butt" as const;
+const SQUARE_TOOLTIP_MARKER = {
+  dotRadiusFraction: 0,
+  dotVariant: "ring",
+} as const;
+
 interface DailyDownloadsChartProps {
   data: DownloadDay[];
 }
@@ -54,7 +67,7 @@ function DailyDownloadsChart({ data }: DailyDownloadsChartProps) {
       <Grid />
       <XAxis />
       <Area dataKey="downloads" fill={SERIES_COLOR} stroke={SERIES_COLOR} />
-      <ChartTooltip />
+      <ChartTooltip {...SQUARE_TOOLTIP_MARKER} />
     </AreaChart>
   );
 }
@@ -74,8 +87,8 @@ function VersionDownloadsChart({ data }: VersionDownloadsChartProps) {
     >
       <Grid />
       <BarXAxis />
-      <Bar dataKey="downloads" fill={SERIES_COLOR} />
-      <ChartTooltip />
+      <Bar dataKey="downloads" fill={SERIES_COLOR} lineCap={SQUARE_BAR_CAP} />
+      <ChartTooltip {...SQUARE_TOOLTIP_MARKER} />
     </BarChart>
   );
 }


### PR DESCRIPTION
## What

`/stats` was the only page on the site with rounded corners. The rest of the `radix-sera` preset is squared throughout — every `components/ui` primitive carries an explicit `rounded-none`. This brings the page in line.

**Page surfaces** (`app/stats/page.tsx`)
- stat tiles: `rounded-lg` → `rounded-none`
- "stats unavailable" notice: `rounded-lg` → `rounded-none`
- inline `@shadscan/cli` code chip: `rounded` → `rounded-none`

**Chart marks** (`components/stats-charts.tsx`) — squared at the call site through the chart primitives' own props, so a registry update doesn't clobber it:
- `lineCap="butt"` on `<Bar>` flattens the 8px rounded bar caps (`rx="8"` → no `rx`)
- `dotVariant="ring"` + `dotRadiusFraction: 0` on `<ChartTooltip>` turns the circular hover marker into a square

**Tooltip chrome** (`components/charts/tooltip/`) — these hardcode their radii and expose no prop to override, so they're squared directly: the tooltip panel (`rounded-lg`), the legend swatch (`rounded-full`), and the date pill (`rounded-full`). All three are only reachable from `/stats`.

## Verification

- Rendered `/stats` in the browser: tiles, code chip, and bar caps all compute to `border-radius: 0` / no `rx`.
- `pnpm dlx ultracite check` — 372 files, clean
- `pnpm ci:typecheck` — passes
- `pnpm exec playwright test test/e2e/stats-page.spec.ts` — 5/5 passing
- `pnpm ci:audit-self` — 100/100 (Grade A), gate passes

The tooltip only appears on a real pointer hover, which I couldn't drive in the preview pane — those three changes are verified as class swaps, not rendered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated stats tiles, chart tooltips, labels, and indicators with square corners.
  * Adjusted chart bars and tooltip markers to use squared visual styling.
  * No functional behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->