### PR TITLE
feat(site): give /stats complete metadata and a social card

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -41,6 +41,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: new URL("/contributors", siteUrl).href,
     },
     {
+      changeFrequency: "daily",
+      priority: 0.5,
+      url: new URL("/stats", siteUrl).href,
+    },
+    {
       changeFrequency: "yearly",
       priority: 0.2,
       url: new URL("/privacy", siteUrl).href,

--- a/app/stats/opengraph-image.tsx
+++ b/app/stats/opengraph-image.tsx
@@ -1,0 +1,28 @@
+import { ImageResponse } from "next/og";
+import { SocialCard } from "@/components/social-card";
+import { getNpmStats } from "@/lib/npm-stats";
+import { createStatsSocialCopy } from "@/lib/stats-social-copy";
+
+const size = {
+  height: 630,
+  width: 1200,
+};
+
+const alt = "shadscan usage stats: npm downloads and version adoption";
+const contentType = "image/png";
+
+// Matches the page's own refresh so a shared card never cites numbers the page
+// has already moved past. Segment config must be a literal.
+export const revalidate = 3600;
+
+export default async function OpenGraphImage() {
+  const stats = await getNpmStats().catch(() => null);
+  const { detail, footer, headline } = createStatsSocialCopy(stats);
+
+  return new ImageResponse(
+    <SocialCard detail={detail} footer={footer} headline={headline} />,
+    size
+  );
+}
+
+export { alt, contentType, size };

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import {
   DailyDownloadsChart,
   VersionDownloadsChart,
@@ -6,14 +5,18 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { getNpmStats, PACKAGE_NAME } from "@/lib/npm-stats";
 import { getHeaderGitHubRepository } from "@/lib/public-github-repository";
+import { createPageMetadata } from "@/lib/site-metadata";
 
 export const revalidate = 3600;
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   description:
     "npm downloads, version adoption, and repository stats for the shadscan CLI.",
-  title: "Stats",
-};
+  imageAlt: "shadscan usage stats: npm downloads and version adoption",
+  imagePath: "/stats/opengraph-image",
+  path: "/stats",
+  title: "Shadscan usage stats",
+});
 
 const COMPACT = new Intl.NumberFormat("en-US", {
   compactDisplay: "short",

--- a/lib/stats-social-copy.ts
+++ b/lib/stats-social-copy.ts
@@ -1,0 +1,53 @@
+import type { NpmStats } from "@/lib/npm-stats";
+
+interface StatsSocialCopy {
+  detail: string;
+  footer: string;
+  headline: string;
+}
+
+const COMPACT_DOWNLOADS = new Intl.NumberFormat("en-US", {
+  compactDisplay: "short",
+  maximumFractionDigits: 1,
+  notation: "compact",
+});
+
+const HEADLINE = "shadscan by the numbers.";
+// The page is explicit that these counts include CI and mirrors, so the card
+// says "downloads" rather than implying a headcount.
+const FALLBACK_DETAIL =
+  "npm downloads, version adoption, and repository stats.";
+const FOOTER = "Public npm numbers, refreshed hourly.";
+const SEGMENT_SEPARATOR = "  ·  ";
+
+/**
+ * Social card copy for /stats. Falls back to a static description whenever npm
+ * has not answered, so the card renders even when the page cannot show numbers.
+ */
+const createStatsSocialCopy = (stats: NpmStats | null): StatsSocialCopy => {
+  if (stats === null) {
+    return { detail: FALLBACK_DETAIL, footer: FOOTER, headline: HEADLINE };
+  }
+
+  const segments = [
+    `${COMPACT_DOWNLOADS.format(stats.totalDownloads)} downloads`,
+  ];
+
+  if (stats.versionCount > 0) {
+    const versionNoun = stats.versionCount === 1 ? "version" : "versions";
+    segments.push(`${stats.versionCount} ${versionNoun}`);
+  }
+
+  if (stats.latestVersion !== null) {
+    segments.push(`v${stats.latestVersion} latest`);
+  }
+
+  return {
+    detail: segments.join(SEGMENT_SEPARATOR),
+    footer: FOOTER,
+    headline: HEADLINE,
+  };
+};
+
+export type { StatsSocialCopy };
+export { createStatsSocialCopy };

--- a/test/e2e/metadata.spec.ts
+++ b/test/e2e/metadata.spec.ts
@@ -54,6 +54,14 @@ const PAGE_METADATA = [
     socialTitle: "Shadscan contributors | shadscan",
   },
   {
+    browserTitle: "Shadscan usage stats | shadscan",
+    description:
+      "npm downloads, version adoption, and repository stats for the shadscan CLI.",
+    imagePath: "/stats/opengraph-image",
+    path: "/stats",
+    socialTitle: "Shadscan usage stats | shadscan",
+  },
+  {
     browserTitle: "Privacy Policy | shadscan",
     description:
       "How Shadscan processes repository scans, request data, local preferences, and communications.",
@@ -262,6 +270,7 @@ for (const imagePath of [
   "/docs/opengraph-image",
   "/sponsors/opengraph-image",
   "/contributors/opengraph-image",
+  "/stats/opengraph-image",
 ]) {
   test(`renders the 1200x630 social card at ${imagePath}`, async ({
     request,

--- a/test/shadscan-web/stats-social-copy.test.ts
+++ b/test/shadscan-web/stats-social-copy.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { NpmStats } from "@/lib/npm-stats";
+import { createStatsSocialCopy } from "@/lib/stats-social-copy";
+
+const createStats = (overrides: Partial<NpmStats> = {}): NpmStats => ({
+  daily: [],
+  firstPublishedDay: "2026-07-22",
+  lastWeekDownloads: 9631,
+  latestVersion: "0.8.0",
+  releases: [],
+  totalDownloads: 45_231,
+  versionCount: 12,
+  versions: [],
+  ...overrides,
+});
+
+describe("stats social card copy", () => {
+  it("cites downloads, version count, and the latest release", () => {
+    expect(createStatsSocialCopy(createStats())).toEqual({
+      detail: "45.2K downloads  ·  12 versions  ·  v0.8.0 latest",
+      footer: "Public npm numbers, refreshed hourly.",
+      headline: "shadscan by the numbers.",
+    });
+  });
+
+  it("falls back to a static description when npm did not answer", () => {
+    expect(createStatsSocialCopy(null)).toEqual({
+      detail: "npm downloads, version adoption, and repository stats.",
+      footer: "Public npm numbers, refreshed hourly.",
+      headline: "shadscan by the numbers.",
+    });
+  });
+
+  it("keeps the card renderable when npm reports no latest version", () => {
+    expect(
+      createStatsSocialCopy(createStats({ latestVersion: null })).detail
+    ).toBe("45.2K downloads  ·  12 versions");
+  });
+
+  it("omits the version segment before anything is published", () => {
+    expect(
+      createStatsSocialCopy(
+        createStats({ latestVersion: null, versionCount: 0 })
+      ).detail
+    ).toBe("45.2K downloads");
+  });
+
+  it("singularizes a lone published version", () => {
+    expect(
+      createStatsSocialCopy(
+        createStats({ latestVersion: "0.1.0", versionCount: 1 })
+      ).detail
+    ).toBe("45.2K downloads  ·  1 version  ·  v0.1.0 latest");
+  });
+
+  it("compacts large download counts", () => {
+    expect(
+      createStatsSocialCopy(createStats({ totalDownloads: 1_240_000 })).detail
+    ).toContain("1.2M downloads");
+  });
+
+  it("leaves small download counts uncompacted", () => {
+    expect(
+      createStatsSocialCopy(createStats({ totalDownloads: 842 })).detail
+    ).toContain("842 downloads");
+  });
+});


### PR DESCRIPTION
`/stats` was the one public page that hand-rolled its own `Metadata` object instead of going through `createPageMetadata`:

```ts
export const metadata: Metadata = {
  description: "npm downloads, version adoption, and repository stats…",
  title: "Stats",
};
```

That left it with no canonical URL, no OpenGraph block, no Twitter card, and no social image — so sharing the link anywhere rendered it untitled and imageless. It was also missing from the sitemap.

## What's here

- **Metadata** — routed through `createPageMetadata`, same as every other page, so canonical / OpenGraph / Twitter all derive from one description. Title becomes `Shadscan usage stats` (the `h1` stays `Stats`; its e2e spec only asserts the heading).
- **`app/stats/opengraph-image.tsx`** — a card that actually cites the numbers it advertises: downloads, versions published, latest release. It reuses the existing `SocialCard`, so it sits in the same visual family as the other five.
- **`lib/stats-social-copy.ts`** — the copy-building logic lives here rather than in the route, so the number formatting and the npm-is-down fallback are unit-testable without rendering a PNG.
- **Sitemap** — `/stats` added at `daily`, matching how often the numbers move.

The image carries its own `revalidate = 3600` so it refreshes in step with the page rather than freezing at build time. It's the only OG route with a revalidate, which the build output now reflects:

```
├ ○ /stats                                 1h      1y
├ ○ /stats/opengraph-image                 1h      1y
```

## Verification

| Gate | Result |
| --- | --- |
| `ultracite check` | clean |
| `tsc --noEmit` | clean |
| `vitest run test/shadscan-web` | 171 passed (7 new) |
| `playwright test` | 67 passed (2 new) |
| `next build` | `/stats/opengraph-image` prerendered, 1h revalidate |

New e2e asserts the full metadata block for `/stats` and that the card is a 1200×630 PNG. Rendered card checked visually.

**One caveat on coverage:** the npm-unavailable fallback is verified by unit test, not end to end. `getNpmStats` runs inside `unstable_cache`, which sits outside the request context the Playwright test proxy patches, so the OG route reads through to real npm regardless of the mock. The fallback string is deterministic and `SocialCard` renders arbitrary strings, so the risk is confined to copy, not rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Stats page to the site sitemap.
  - Added a dedicated social preview image for Stats pages, including download and release information.
  - Improved Stats page metadata for richer search and social sharing previews.
  - Added fallback messaging when usage statistics are unavailable.

- **Tests**
  - Expanded metadata and social-card coverage for the Stats page.
  - Added validation for download formatting, release details, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->