### PR TITLE
feat(cli): serve shadscan over MCP with `shadscan mcp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ stable releases published under `latest`.
 
 ## Unreleased
 
+### Added
+
+- An MCP server: `shadscan mcp` serves the audit over the Model Context
+  Protocol on stdio, with three read-only tools — `scan` (score plus
+  actionables, filterable by category, severity, or workspace package),
+  `list_projects`, and `explain_rule`. Every call re-scans the current
+  file state rather than answering from a cache, results are neutral
+  (no roast copy), tool calls can only read inside the roots the server
+  was started with, and every response carries the engine, ruleset, and
+  schema versions. The library API now also exports `scanWorkspace` and
+  `discoverWorkspace`. The MCP SDK is bundled at build time, so the
+  published package still installs the same six runtime dependencies;
+  the packed-CLI smoke test audits the bundle to keep the SDK's HTTP
+  transports out.
+
 ## 0.8.0 - 2026-07-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -181,6 +181,25 @@ Codex CLI, or Grok Build executable before launching it. Shadscan itself still
 does not make an AI request; the selected external agent follows its own
 provider and approval model.
 
+## MCP Server
+
+`shadscan mcp` serves the same deterministic audit over the Model Context
+Protocol on stdio, so coding agents can query results as typed tool calls
+instead of parsing output:
+
+```bash
+claude mcp add shadscan -- npx -y @shadscan/cli mcp
+```
+
+Three read-only tools: `scan` (score plus filterable actionables — by
+category, severity, or workspace package), `list_projects` (workspace
+packages with their application-or-library classification), and
+`explain_rule` (what one rule checks and where it applies). Every call
+re-scans the current file state — results are never cached — and every
+response carries the engine, ruleset, and schema versions. The server scans
+inside the roots it was started with and nothing else, and it never writes
+files. Details and per-client setup live in [docs/mcp.md](docs/mcp.md).
+
 ## What It Checks
 
 The bundled ruleset contains 59 deterministic checks across six weighted

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -461,6 +461,38 @@ export default function DocsPage() {
           />
         </section>
 
+        <section id="mcp-server">
+          <h2>MCP server</h2>
+          <p>
+            <code>shadscan mcp</code> serves the audit over the Model Context
+            Protocol on stdio, so coding agents query results as typed tool
+            calls instead of parsing output. Three read-only tools:{" "}
+            <code>scan</code> returns the score and actionables, filterable by
+            category, severity, or workspace package; <code>list_projects</code>{" "}
+            classifies a monorepo&apos;s packages; <code>explain_rule</code>{" "}
+            describes one rule. Every call re-scans the current file state —
+            results are never cached — and the server only reads inside the
+            roots it was started with.
+          </p>
+          <DocsCodeBlock
+            code="claude mcp add shadscan -- npx -y @shadscan/cli mcp"
+            label="Claude Code"
+            language="bash"
+          />
+          <p>
+            Setup for other clients, the tool reference, and the security
+            posture live in the{" "}
+            <a
+              href="https://github.com/TheOrcDev/shadscan/blob/main/docs/mcp.md"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              MCP runbook
+            </a>
+            .
+          </p>
+        </section>
+
         <section id="project-rule">
           <h2>Make it a project rule</h2>
           <p>

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -42,6 +42,10 @@ shadscan setup [path] --pre-commit [--dry-run | --yes]
   visible, and depends on stderr terminal capabilities rather than stdin or
   stdout TTY state. JSON, prompt, CI, non-TTY stderr, and `--no-interactive`
   scans suppress progress.
+- Under `shadscan mcp`, stdout carries JSON-RPC exclusively; stderr carries a
+  single startup line and abnormal-exit diagnostics. Tool errors return as
+  MCP error results with the same stable public messages as CLI failures,
+  never as raw stream writes. All other output contracts are unchanged.
 - Evidence paths are project-relative and never contain the scanner machine's
   absolute project path.
 - Agent handoffs treat repository instructions and discovered package scripts

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,167 @@
+# The shadscan MCP server
+
+`shadscan mcp` serves shadscan over the Model Context Protocol on stdio, so
+coding agents can query audit results as typed tool calls instead of parsing
+CLI output. It ships inside `@shadscan/cli` — there is no separate package,
+and the server version is always the CLI version.
+
+## The contract: every call re-scans
+
+The server holds no result state. Every `scan` call reads the project as it
+is on disk at that moment; nothing is cached between calls. shadscan is
+deterministic over file state, so the moment an agent edits a file any cached
+answer would be wrong — precisely when the agent most needs the truth. Scans
+cost roughly one second on a typical project (large monorepos can take
+~30 seconds), which buys correctness on every call.
+
+The loop this enables: fix something, call `scan` again, read the delta.
+
+## Setup
+
+The server takes root directories as arguments; tool calls may only scan
+inside them. With no arguments it serves the directory it was launched in.
+
+### Claude Code
+
+```bash
+claude mcp add shadscan -- npx -y @shadscan/cli mcp
+```
+
+### Cursor
+
+Settings → MCP → Add new server, or `.cursor/mcp.json` in the project:
+
+```json
+{
+  "mcpServers": {
+    "shadscan": {
+      "command": "npx",
+      "args": ["-y", "@shadscan/cli", "mcp"]
+    }
+  }
+}
+```
+
+### VS Code
+
+`.vscode/mcp.json` in the workspace:
+
+```json
+{
+  "servers": {
+    "shadscan": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@shadscan/cli", "mcp"]
+    }
+  }
+}
+```
+
+### Any other MCP client
+
+Command `npx`, arguments `["-y", "@shadscan/cli", "mcp", "<root>"]`,
+transport stdio. The server speaks MCP protocol revision `2025-06-18` and
+newer (SDK-negotiated). In CI, pin an exact version
+(`@shadscan/cli@<version>`) the same way you would for the CLI.
+
+## Tools
+
+### `scan`
+
+Audits a project and returns its score plus actionable findings. Re-scans on
+every call.
+
+| Input | Type | Meaning |
+|---|---|---|
+| `path` | string? | Directory to scan, relative to the first root. Default: the first root. |
+| `category` | enum? | One audit category (`foundation`, `interaction`, `states`, `accessibility`, `forms`, `production-polish`). |
+| `severity` | enum? | `error` or `warning`. |
+| `packageDir` | string? | One workspace package (monorepos). Unknown values fail with the list of valid ones. |
+| `full` | boolean? | Include the complete findings array, not just actionables. |
+
+The compact response (default) carries the score, grade, per-category
+counts, and actionables — each with `findingId`, `priority`, `scoreImpact`,
+`suggestedFix`, `acceptanceCriteria`, and its first evidence location. When
+more than 50 actionables match, the response keeps the 20 with the highest
+score impact and says so in `actionablesNote` — the server never truncates
+silently.
+
+A real filtered response, trimmed to one actionable:
+
+```json
+{
+  "engineVersion": "0.8.0",
+  "rulesetVersion": "2026.07.41",
+  "schemaVersion": 9,
+  "actionables": [
+    {
+      "findingId": "theme-provider-configured",
+      "title": "Fix theme provider configured",
+      "priority": "P1",
+      "scoreImpact": 5,
+      "severity": "warning",
+      "status": "fail",
+      "packageDir": "apps/web",
+      "suggestedFix": "Mount a theme provider near the app shell and connect it to the dark-mode class.",
+      "evidence": { "message": "No theme provider or theme management was found." }
+    }
+  ],
+  "actionablesNote": null,
+  "countsByCategory": { "foundation": 7 },
+  "grade": "F",
+  "score": 36,
+  "workspace": { "applicationCount": 2, "kind": "pnpm", "skippedCount": 1 }
+}
+```
+
+Every response carries `engineVersion`, `rulesetVersion`, and
+`schemaVersion`, so results from different shadscan versions are never
+silently compared.
+
+### `list_projects`
+
+Lists the packages shadscan can audit under a workspace root, each
+classified as an `application` or a `library` with the reason. Call it
+before `scan` on a monorepo to learn the valid `packageDir` values.
+
+### `explain_rule`
+
+Explains one rule: what it checks, its category, which framework adapters it
+applies to, and its confidence. Rule ids come from scan results as
+`findingId`; unknown ids answer with the nearest matching ids, since agents
+habitually guess kebab-case names.
+
+## Security posture
+
+- **Roots are fixed at launch.** `shadscan mcp <path> [path...]` — tool
+  calls cannot widen them, and out-of-root paths fail with a stable message
+  naming the allowed roots.
+- **Read-only.** The server scans; it never writes files, runs package
+  scripts, or touches the network.
+- **Neutral output.** Roast copy is stripped from all MCP responses.
+- **Redacted errors.** Unexpected failures return a generic message rather
+  than scanner filesystem detail, matching the CLI's error contract.
+
+## Operational notes
+
+- **Scans are serialized.** Concurrent `scan` calls queue rather than run in
+  parallel; two simultaneous scans of a large repository would compete for
+  memory, not finish faster.
+- **Client timeouts.** A large monorepo can take ~30 seconds; if your client
+  defaults to a short tool timeout, raise it for this server.
+- **stdout is protocol.** The server prints exactly one startup line to
+  stderr and keeps stdout pure JSON-RPC. If you see anything else on stdout,
+  that is a bug — please report it.
+
+## Troubleshooting
+
+- **"Path is outside the allowed roots"** — the most common error. Start the
+  server with the directory you want scanned:
+  `npx -y @shadscan/cli mcp /path/to/repo`, or add more roots as extra
+  arguments.
+- **"The nearest package does not declare React"** — the scanned directory
+  is not a React project. On a monorepo, scan the workspace root (shadscan
+  pools every application) or pass `packageDir`.
+- **Slow first call** — `npx -y` downloads the package on first use; pin and
+  pre-install `@shadscan/cli` where startup latency matters.

--- a/lib/docs-sections.ts
+++ b/lib/docs-sections.ts
@@ -9,6 +9,7 @@ const DOCS_SECTIONS = [
   { href: "#github-action", label: "GitHub Action" },
   { href: "#pre-commit", label: "Pre-commit gate" },
   { href: "#agent-skill", label: "Agent skill" },
+  { href: "#mcp-server", label: "MCP server" },
   { href: "#project-rule", label: "Project rule" },
   { href: "#troubleshooting", label: "Troubleshooting" },
 ] as const satisfies readonly DocsSection[];

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -137,6 +137,25 @@ Codex CLI, or Grok Build executable before launching it. Shadscan itself still
 does not make an AI request; the selected external agent follows its own
 provider and approval model.
 
+## MCP Server
+
+`shadscan mcp` serves the same deterministic audit over the Model Context
+Protocol on stdio, so coding agents can query results as typed tool calls
+instead of parsing output:
+
+```bash
+claude mcp add shadscan -- npx -y @shadscan/cli mcp
+```
+
+Three read-only tools: `scan` (score plus filterable actionables — by
+category, severity, or workspace package), `list_projects` (workspace
+packages with their application-or-library classification), and
+`explain_rule` (what one rule checks and where it applies). Every call
+re-scans the current file state — results are never cached — and every
+response carries the engine, ruleset, and schema versions. The server scans
+inside the roots it was started with and nothing else, and it never writes
+files. Details and per-client setup live in [docs/mcp.md](https://github.com/TheOrcDev/shadscan/blob/main/docs/mcp.md).
+
 ## Before Every Agent Commit
 
 Install the optional AI-agent commit protocol:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -69,6 +69,7 @@
     "zod": "4.1.13"
   },
   "devDependencies": {
+    "@modelcontextprotocol/sdk": "1.30.0",
     "@types/node": "18.19.130",
     "commander": "13.1.0",
     "execa": "9.6.1",

--- a/packages/cli/scripts/smoke-package.mjs
+++ b/packages/cli/scripts/smoke-package.mjs
@@ -255,8 +255,105 @@ try {
   );
   await run(process.execPath, [importCheckPath], { cwd: consumerDirectory });
 
+  // --- MCP bundle audit -----------------------------------------------------
+  // The MCP SDK is a bundled devDependency; its HTTP transports (express,
+  // hono, and friends) must never reach the shipped bundle. Import
+  // specifiers surviving in dist/cli.js would mean esbuild left them
+  // external — a runtime crash for users; their absence plus the size guard
+  // means they were neither imported nor inlined.
+  const bundlePath = path.join(
+    consumerDirectory,
+    "node_modules",
+    "@shadscan",
+    "cli",
+    "dist",
+    "cli.js"
+  );
+  const bundle = await readFile(bundlePath, "utf8");
+  const forbiddenSpecifiers = [
+    "express",
+    "hono",
+    "@hono/node-server",
+    "cors",
+    "jose",
+    "eventsource",
+    "express-rate-limit",
+    "raw-body",
+    "pkce-challenge",
+  ];
+  for (const specifier of forbiddenSpecifiers) {
+    const importPattern = new RegExp(
+      `(?:from\\s*|require\\()["']${specifier.replace("/", "\\/")}["']`
+    );
+    assert.ok(
+      !importPattern.test(bundle),
+      `dist/cli.js references "${specifier}"; the MCP HTTP stack leaked into the bundle.`
+    );
+  }
+  const bundleBytes = Buffer.byteLength(bundle);
+  assert.ok(
+    bundleBytes < 2_500_000,
+    `dist/cli.js is ${bundleBytes} bytes; expected the stdio-only MCP bundle to stay under 2.5MB.`
+  );
+
+  // --- MCP stdio roundtrip --------------------------------------------------
+  // Drive the packed binary end to end over real stdio: initialize,
+  // tools/list, then a scan of the consumer project. Every stdout line must
+  // parse as JSON — one stray write corrupts the protocol.
+  const mcpMessages = [
+    {
+      id: 1,
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        capabilities: {},
+        clientInfo: { name: "smoke", version: "0.0.0" },
+        protocolVersion: "2025-06-18",
+      },
+    },
+    { jsonrpc: "2.0", method: "notifications/initialized" },
+    { id: 2, jsonrpc: "2.0", method: "tools/list" },
+    {
+      id: 3,
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: { arguments: {}, name: "scan" },
+    },
+  ];
+  const mcpResult = await execa(executable, ["mcp", consumerDirectory], {
+    cwd: consumerDirectory,
+    env: { CI: "1", NO_COLOR: "1", npm_config_cache: npmCacheDirectory },
+    input: `${mcpMessages.map((message) => JSON.stringify(message)).join("\n")}\n`,
+    reject: false,
+    timeout: 120_000,
+  });
+  const mcpLines = mcpResult.stdout.split("\n").filter(Boolean);
+  assert.ok(mcpLines.length >= 3, "Expected three JSON-RPC responses.");
+  const mcpParsed = [];
+  for (const line of mcpLines) {
+    try {
+      mcpParsed.push(JSON.parse(line));
+    } catch {
+      assert.fail(
+        `Non-JSON output on the MCP stdout stream: ${line.slice(0, 120)}`
+      );
+    }
+  }
+  const toolsListResponse = mcpParsed.find((message) => message.id === 2);
+  assert.ok(toolsListResponse, "Missing tools/list response.");
+  assert.deepEqual(
+    toolsListResponse.result.tools.map((tool) => tool.name).sort(),
+    ["explain_rule", "list_projects", "scan"]
+  );
+  const scanResponse = mcpParsed.find((message) => message.id === 3);
+  assert.ok(scanResponse, "Missing scan response.");
+  const scanPayload = JSON.parse(scanResponse.result.content[0].text);
+  assert.equal(scanPayload.engineVersion, packageManifest.version);
+  assert.ok(Number.isInteger(scanPayload.score));
+  assert.ok(Array.isArray(scanPayload.actionables));
+
   process.stdout.write(
-    `Packed shadscan ${packageManifest.version} passed npx, install, bin, output, threshold, and import smoke tests.\n`
+    `Packed shadscan ${packageManifest.version} passed npx, install, bin, output, threshold, import, MCP bundle-audit, and MCP stdio smoke tests.\n`
   );
 } finally {
   await rm(temporaryRoot, { force: true, recursive: true });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -808,6 +808,20 @@ const createProgram = (): Command => {
     )
     .action(runSetupAction);
 
+  program
+    .command("mcp")
+    .description(
+      "Serve shadscan as an MCP server over stdio for coding agents."
+    )
+    .argument("[paths...]", "Root directories tool calls may scan.", undefined)
+    .action(async (paths: string[]) => {
+      // stdout carries JSON-RPC exclusively in this mode; the server writes
+      // its one startup line to stderr. Lazy import keeps the MCP bundle out
+      // of ordinary scan startup.
+      const { runMcpServer } = await import("./mcp/server");
+      await runMcpServer(paths ?? []);
+    });
+
   return program;
 };
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,8 +33,15 @@ export type { RuleCatalogEntry } from "./rule-catalog";
 export { RULE_CATALOG } from "./rule-catalog";
 export type { ScanOptions } from "./scan";
 export { BUNDLED_RULESET_VERSION, scanProject } from "./scan";
+export { scanWorkspace } from "./scan-workspace";
 export {
   classifyScanInputPath,
   SCAN_SOURCE_LIMITS,
   type ScanInputRetention,
 } from "./source-requirements";
+export type {
+  WorkspaceDiscovery,
+  WorkspaceProject,
+  WorkspaceProjectKind,
+} from "./workspace";
+export { discoverWorkspace } from "./workspace";

--- a/packages/cli/src/mcp/contracts.ts
+++ b/packages/cli/src/mcp/contracts.ts
@@ -1,0 +1,123 @@
+import { z } from "zod";
+import { AUDIT_CATEGORIES } from "../audit";
+
+/**
+ * MCP is the fourth consumer of the report shape (CLI, hosted API, GitHub
+ * Action, MCP). Tool responses are derived subsets validated here at the
+ * boundary, so a future report-schema bump fails loudly in this file instead
+ * of silently changing tool output.
+ */
+
+const SEVERITIES = ["error", "warning"] as const;
+
+const ScanInputSchema = z.object({
+  category: z.enum(AUDIT_CATEGORIES).optional(),
+  full: z.boolean().optional(),
+  packageDir: z.string().min(1).optional(),
+  path: z.string().min(1).optional(),
+  severity: z.enum(SEVERITIES).optional(),
+});
+
+const ListProjectsInputSchema = z.object({
+  path: z.string().min(1).optional(),
+});
+
+const ExplainRuleInputSchema = z.object({
+  ruleId: z.string().min(1),
+});
+
+const VersionsSchema = z.object({
+  engineVersion: z.string(),
+  rulesetVersion: z.string(),
+  schemaVersion: z.number(),
+});
+
+const ActionableSummarySchema = z.object({
+  acceptanceCriteria: z.array(z.string()),
+  category: z.string(),
+  evidence: z
+    .object({
+      filePath: z.string().optional(),
+      line: z.number().optional(),
+      message: z.string(),
+    })
+    .nullable(),
+  findingId: z.string(),
+  packageDir: z.string().nullable(),
+  priority: z.string(),
+  scoreImpact: z.number(),
+  severity: z.string(),
+  status: z.string(),
+  suggestedFix: z.string().nullable(),
+  title: z.string(),
+});
+
+const ScanResultSchema = VersionsSchema.extend({
+  actionables: z.array(ActionableSummarySchema),
+  /** Set when the actionable list was capped; explains what was kept. */
+  actionablesNote: z.string().nullable(),
+  countsByCategory: z.record(z.string(), z.number()),
+  findings: z.array(z.unknown()).nullable(),
+  grade: z.string().nullable(),
+  packageDirs: z.array(z.string()).nullable(),
+  score: z.number().nullable(),
+  scannedPath: z.string(),
+  workspace: z
+    .object({
+      applicationCount: z.number(),
+      kind: z.string(),
+      skippedCount: z.number(),
+    })
+    .nullable(),
+});
+
+const ListProjectsResultSchema = VersionsSchema.omit({
+  schemaVersion: true,
+}).extend({
+  kind: z.string(),
+  projects: z.array(
+    z.object({
+      adapter: z.string(),
+      kind: z.string(),
+      kindReason: z.string(),
+      packageDir: z.string(),
+      packageName: z.string().nullable(),
+    })
+  ),
+  scannedPath: z.string(),
+  skipped: z.array(z.object({ packageDir: z.string(), reason: z.string() })),
+  truncated: z.number(),
+});
+
+const ExplainRuleResultSchema = z.object({
+  adapters: z.array(z.string()),
+  category: z.string(),
+  confidence: z.string(),
+  description: z.string(),
+  id: z.string(),
+  title: z.string(),
+});
+
+type ScanInput = z.infer<typeof ScanInputSchema>;
+type ScanResult = z.infer<typeof ScanResultSchema>;
+type ListProjectsInput = z.infer<typeof ListProjectsInputSchema>;
+type ListProjectsResult = z.infer<typeof ListProjectsResultSchema>;
+type ExplainRuleInput = z.infer<typeof ExplainRuleInputSchema>;
+type ExplainRuleResult = z.infer<typeof ExplainRuleResultSchema>;
+
+export type {
+  ExplainRuleInput,
+  ExplainRuleResult,
+  ListProjectsInput,
+  ListProjectsResult,
+  ScanInput,
+  ScanResult,
+};
+export {
+  ExplainRuleInputSchema,
+  ExplainRuleResultSchema,
+  ListProjectsInputSchema,
+  ListProjectsResultSchema,
+  ScanInputSchema,
+  ScanResultSchema,
+};

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -1,0 +1,122 @@
+import path from "node:path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import packageJson from "../../package.json";
+import {
+  ExplainRuleInputSchema,
+  ListProjectsInputSchema,
+  ScanInputSchema,
+} from "./contracts";
+import {
+  explainRuleTool,
+  listProjectsTool,
+  type McpToolsOptions,
+  scanTool,
+  toToolErrorMessage,
+} from "./tools";
+
+/**
+ * Every tool call runs a fresh scan; the server holds no result state.
+ * shadscan is deterministic over file state, so the moment an agent edits a
+ * file any cached answer is wrong — precisely when the agent most needs the
+ * truth. Scans cost roughly one second on a typical project, which is cheap
+ * enough to buy correctness on every call.
+ */
+
+const asToolResult = (payload: unknown) => ({
+  content: [{ text: JSON.stringify(payload, null, 2), type: "text" as const }],
+});
+
+const asToolError = (error: unknown) => ({
+  content: [{ text: toToolErrorMessage(error), type: "text" as const }],
+  isError: true as const,
+});
+
+const createShadscanMcpServer = (options: McpToolsOptions): McpServer => {
+  const server = new McpServer({
+    name: "shadscan",
+    version: packageJson.version,
+  });
+
+  server.registerTool(
+    "scan",
+    {
+      description:
+        "Audit a React shadcn project and return its score plus actionable findings. Re-scans the current file state on every call — results are never cached, so call it again after editing to see the delta. Filter with category, severity, or packageDir (monorepos); set full=true for the complete findings list.",
+      inputSchema: ScanInputSchema.shape,
+    },
+    async (input, extra) => {
+      try {
+        return asToolResult(
+          await scanTool(options, ScanInputSchema.parse(input), extra.signal)
+        );
+      } catch (error) {
+        return asToolError(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "list_projects",
+    {
+      description:
+        "List the packages shadscan can audit under a workspace root, with each one classified as an application or a library and the reason for the classification. Use before scan on a monorepo to learn the packageDir values.",
+      inputSchema: ListProjectsInputSchema.shape,
+    },
+    async (input) => {
+      try {
+        return asToolResult(
+          await listProjectsTool(options, ListProjectsInputSchema.parse(input))
+        );
+      } catch (error) {
+        return asToolError(error);
+      }
+    }
+  );
+
+  server.registerTool(
+    "explain_rule",
+    {
+      description:
+        "Explain one shadscan rule: what it checks, its category, which framework adapters it applies to, and its confidence level. Rule ids come from scan results as findingId.",
+      inputSchema: ExplainRuleInputSchema.shape,
+    },
+    (input) => {
+      try {
+        return asToolResult(
+          explainRuleTool(ExplainRuleInputSchema.parse(input))
+        );
+      } catch (error) {
+        return asToolError(error);
+      }
+    }
+  );
+
+  return server;
+};
+
+/**
+ * stdout belongs to JSON-RPC from here on; the single startup line and any
+ * abnormal-exit diagnostics go to stderr, then silence.
+ */
+const runMcpServer = async (rootArguments: string[]): Promise<void> => {
+  const roots = (rootArguments.length > 0 ? rootArguments : ["."]).map((root) =>
+    path.resolve(root)
+  );
+  const server = createShadscanMcpServer({ roots });
+  const transport = new StdioServerTransport();
+
+  const shutdown = async () => {
+    await server.close().catch(() => undefined);
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  await server.connect(transport);
+  process.stderr.write(
+    `shadscan mcp ${packageJson.version} serving ${roots.join(", ")} over stdio\n`
+  );
+};
+
+export { createShadscanMcpServer, runMcpServer };

--- a/packages/cli/src/mcp/tools.ts
+++ b/packages/cli/src/mcp/tools.ts
@@ -1,0 +1,294 @@
+import path from "node:path";
+import packageJson from "../../package.json";
+import {
+  type AgentActionable,
+  AUDIT_REPORT_SCHEMA_VERSION,
+  type AuditReport,
+} from "../audit";
+import { ProjectDiscoveryError } from "../discovery";
+import { stripRoasts } from "../render-human";
+import { RULE_CATALOG } from "../rule-catalog";
+import { BUNDLED_RULESET_VERSION, scanProject } from "../scan";
+import { scanWorkspace } from "../scan-workspace";
+import { discoverWorkspace } from "../workspace";
+import type {
+  ExplainRuleInput,
+  ExplainRuleResult,
+  ListProjectsInput,
+  ListProjectsResult,
+  ScanInput,
+  ScanResult,
+} from "./contracts";
+
+/**
+ * Compact responses cap the actionable list; beyond this the response keeps
+ * the highest-impact items and says so. Silent truncation reads as "that is
+ * everything", which is the one thing an audit must never imply.
+ */
+const MAX_COMPACT_ACTIONABLES = 20;
+const COMPACT_CAP_THRESHOLD = 50;
+/** Suggestions offered when an unknown rule id is asked for. */
+const NEAREST_RULE_COUNT = 5;
+
+class McpToolError extends Error {}
+
+interface McpToolsOptions {
+  roots: string[];
+}
+
+const VERSIONS = {
+  engineVersion: packageJson.version,
+  rulesetVersion: BUNDLED_RULESET_VERSION,
+  schemaVersion: AUDIT_REPORT_SCHEMA_VERSION,
+};
+
+const isWithin = (root: string, candidate: string): boolean => {
+  const relative = path.relative(root, candidate);
+
+  return (
+    relative === "" ||
+    (!relative.startsWith(`..${path.sep}`) &&
+      relative !== ".." &&
+      !path.isAbsolute(relative))
+  );
+};
+
+/**
+ * Roots are fixed when the server starts; tool calls cannot widen them. The
+ * error deliberately names the allowed roots and nothing else — no scanner
+ * filesystem detail beyond what the client already configured.
+ */
+const resolveScanPath = (roots: string[], requested?: string): string => {
+  const first = roots[0];
+
+  if (first === undefined) {
+    throw new McpToolError("The server was started without any roots.");
+  }
+
+  if (requested === undefined) {
+    return first;
+  }
+
+  const resolved = path.resolve(first, requested);
+  if (roots.some((root) => isWithin(root, resolved))) {
+    return resolved;
+  }
+
+  throw new McpToolError(
+    `Path is outside the allowed roots (${roots.join(", ")}). Start shadscan mcp with additional root arguments to widen access.`
+  );
+};
+
+/**
+ * Scans are serialized: the parsed-file and render-graph caches are
+ * per-project and memory-heavy, and two simultaneous scans of a large
+ * repository is an out-of-memory invitation rather than a speedup.
+ */
+let scanQueue: Promise<unknown> = Promise.resolve();
+
+const enqueue = <Result>(task: () => Promise<Result>): Promise<Result> => {
+  const run = scanQueue.then(task, task);
+  scanQueue = run.catch(() => undefined);
+  return run;
+};
+
+/**
+ * Mirrors the CLI's routing by calling the same exported functions: only a
+ * lone package at the requested root takes the single-package path.
+ */
+const runScan = async (
+  scanPath: string,
+  signal: AbortSignal | undefined
+): Promise<AuditReport> => {
+  const workspace = await discoverWorkspace(scanPath);
+  const onlyProject =
+    workspace.projects.length === 1 ? workspace.projects[0] : null;
+  const scanAsWorkspace =
+    workspace.projects.length > 0 && onlyProject?.packageDir !== ".";
+
+  const report = scanAsWorkspace
+    ? await scanWorkspace(scanPath, { signal })
+    : await scanProject(scanPath, { signal });
+
+  /** Agents quote tool output verbatim; roasts are for humans at a TTY. */
+  return stripRoasts(report);
+};
+
+const toActionableSummary = (actionable: AgentActionable) => ({
+  acceptanceCriteria: actionable.acceptanceCriteria,
+  category: actionable.category,
+  evidence: actionable.evidence[0]
+    ? {
+        filePath: actionable.evidence[0].filePath,
+        line: actionable.evidence[0].line,
+        message: actionable.evidence[0].message,
+      }
+    : null,
+  findingId: actionable.findingId,
+  packageDir: actionable.packageDir,
+  priority: actionable.priority,
+  scoreImpact: actionable.scoreImpact,
+  severity: actionable.severity,
+  status: actionable.status,
+  suggestedFix: actionable.suggestedFix,
+  title: actionable.title,
+});
+
+const filterActionables = (
+  actionables: AgentActionable[],
+  input: ScanInput,
+  availablePackageDirs: string[]
+): AgentActionable[] => {
+  let filtered = actionables;
+
+  if (input.category) {
+    filtered = filtered.filter(
+      (actionable) => actionable.category === input.category
+    );
+  }
+
+  if (input.severity) {
+    filtered = filtered.filter(
+      (actionable) => actionable.severity === input.severity
+    );
+  }
+
+  if (input.packageDir) {
+    if (!availablePackageDirs.includes(input.packageDir)) {
+      throw new McpToolError(
+        availablePackageDirs.length > 0
+          ? `Unknown packageDir "${input.packageDir}". Available: ${availablePackageDirs.join(", ")}.`
+          : "This scan has no per-package results; omit packageDir."
+      );
+    }
+    filtered = filtered.filter(
+      (actionable) => actionable.packageDir === input.packageDir
+    );
+  }
+
+  return filtered;
+};
+
+const scanTool = async (
+  options: McpToolsOptions,
+  input: ScanInput,
+  signal?: AbortSignal
+): Promise<ScanResult> => {
+  const scanPath = resolveScanPath(options.roots, input.path);
+  const report = await enqueue(() => runScan(scanPath, signal));
+  const packageDirs =
+    report.workspace?.projects.map((project) => project.packageDir) ?? null;
+  const filtered = filterActionables(
+    report.agentHandoff.actionables,
+    input,
+    packageDirs ?? []
+  );
+
+  const capped =
+    !input.full && filtered.length > COMPACT_CAP_THRESHOLD
+      ? [...filtered]
+          .sort((left, right) => right.scoreImpact - left.scoreImpact)
+          .slice(0, MAX_COMPACT_ACTIONABLES)
+      : filtered;
+
+  const countsByCategory: Record<string, number> = {};
+  for (const actionable of filtered) {
+    countsByCategory[actionable.category] =
+      (countsByCategory[actionable.category] ?? 0) + 1;
+  }
+
+  return {
+    ...VERSIONS,
+    actionables: capped.map(toActionableSummary),
+    actionablesNote:
+      capped.length < filtered.length
+        ? `${filtered.length} actionables matched; returning the ${capped.length} with the highest score impact. Filter by category, severity, or packageDir to see the rest.`
+        : null,
+    countsByCategory,
+    findings: input.full ? report.findings : null,
+    grade: report.grade,
+    packageDirs,
+    scannedPath: path.relative(options.roots[0] ?? scanPath, scanPath) || ".",
+    score: report.score,
+    workspace: report.workspace
+      ? {
+          applicationCount: report.workspace.applicationCount,
+          kind: report.workspace.kind,
+          skippedCount: report.workspace.skipped.length,
+        }
+      : null,
+  };
+};
+
+const listProjectsTool = async (
+  options: McpToolsOptions,
+  input: ListProjectsInput
+): Promise<ListProjectsResult> => {
+  const scanPath = resolveScanPath(options.roots, input.path);
+  const workspace = await discoverWorkspace(scanPath);
+
+  return {
+    engineVersion: VERSIONS.engineVersion,
+    kind: workspace.kind,
+    projects: workspace.projects.map((project) => ({
+      adapter: project.adapter,
+      kind: project.kind,
+      kindReason: project.kindReason,
+      packageDir: project.packageDir,
+      packageName: project.packageName,
+    })),
+    rulesetVersion: VERSIONS.rulesetVersion,
+    scannedPath: path.relative(options.roots[0] ?? scanPath, scanPath) || ".",
+    skipped: workspace.skipped,
+    truncated: workspace.truncated,
+  };
+};
+
+const explainRuleTool = (input: ExplainRuleInput): ExplainRuleResult => {
+  const rule = RULE_CATALOG.find((entry) => entry.id === input.ruleId);
+
+  if (!rule) {
+    /** Agents habitually guess kebab-case ids; offer the nearest ones. */
+    const nearest = RULE_CATALOG.map((entry) => entry.id)
+      .filter(
+        (id) =>
+          id.startsWith(input.ruleId.split("-")[0] ?? "") ||
+          id.includes(input.ruleId)
+      )
+      .slice(0, NEAREST_RULE_COUNT);
+
+    throw new McpToolError(
+      nearest.length > 0
+        ? `Unknown rule "${input.ruleId}". Did you mean: ${nearest.join(", ")}?`
+        : `Unknown rule "${input.ruleId}". Call scan and use a findingId from the response.`
+    );
+  }
+
+  return {
+    adapters: [...rule.adapters],
+    category: rule.category,
+    confidence: rule.confidence,
+    description: rule.description,
+    id: rule.id,
+    title: rule.title,
+  };
+};
+
+/** Discovery failures carry stable public messages; pass those through. */
+const toToolErrorMessage = (error: unknown): string => {
+  if (error instanceof McpToolError || error instanceof ProjectDiscoveryError) {
+    return error.message;
+  }
+
+  return "The scan failed unexpectedly. Run the shadscan CLI directly for details.";
+};
+
+export type { McpToolsOptions };
+export {
+  explainRuleTool,
+  listProjectsTool,
+  McpToolError,
+  resolveScanPath,
+  scanTool,
+  toToolErrorMessage,
+};

--- a/packages/cli/test/mcp-server.test.ts
+++ b/packages/cli/test/mcp-server.test.ts
@@ -1,0 +1,236 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { createShadscanMcpServer } from "../src/mcp/server";
+import {
+  cleanupWorkspaceFixtures,
+  createWorkspaceFixture,
+} from "./workspace-fixture";
+
+const OUTSIDE_ROOTS_PATTERN = /outside the allowed roots/;
+const RULESET_VERSION_PATTERN = /^\d{4}\./;
+
+interface ToolTextResult {
+  content: { text: string; type: string }[];
+  isError?: boolean;
+}
+
+const connect = async (roots: string[]) => {
+  const server = createShadscanMcpServer({ roots });
+  const client = new Client({ name: "mcp-test", version: "0.0.0" });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  return { client, server };
+};
+
+const callTool = async (
+  client: Client,
+  name: string,
+  args: Record<string, unknown> = {}
+): Promise<{ isError: boolean; payload: unknown; text: string }> => {
+  const result = (await client.callTool({
+    arguments: args,
+    name,
+  })) as ToolTextResult;
+  const text = result.content[0]?.text ?? "";
+
+  let payload: unknown = null;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    payload = null;
+  }
+
+  return { isError: result.isError === true, payload, text };
+};
+
+afterEach(async () => {
+  await cleanupWorkspaceFixtures();
+});
+
+describe("shadscan mcp server", () => {
+  it("lists exactly the three read-only tools", async () => {
+    const rootDir = await createWorkspaceFixture({
+      kind: "none",
+      packages: [{ path: ".", preset: "next" }],
+    });
+    const { client } = await connect([rootDir]);
+
+    const { tools } = await client.listTools();
+
+    expect(tools.map((tool) => tool.name).sort()).toEqual([
+      "explain_rule",
+      "list_projects",
+      "scan",
+    ]);
+  });
+
+  it("scans a project and returns versioned, actionable results", async () => {
+    const rootDir = await createWorkspaceFixture({
+      kind: "none",
+      packages: [{ path: ".", preset: "next" }],
+    });
+    const { client } = await connect([rootDir]);
+
+    const { isError, payload } = await callTool(client, "scan");
+    const result = payload as Record<string, unknown>;
+
+    expect(isError).toBe(false);
+    expect(typeof result.score).toBe("number");
+    expect(result.grade).not.toBeNull();
+    expect(result.rulesetVersion).toMatch(RULESET_VERSION_PATTERN);
+    expect(result.schemaVersion).toBeGreaterThanOrEqual(9);
+    expect(Array.isArray(result.actionables)).toBe(true);
+    expect((result.actionables as unknown[]).length).toBeGreaterThan(0);
+    // Compact mode omits raw findings.
+    expect(result.findings).toBeNull();
+  });
+
+  it("narrows results with category and severity filters", async () => {
+    const rootDir = await createWorkspaceFixture({
+      kind: "none",
+      packages: [{ path: ".", preset: "next" }],
+    });
+    const { client } = await connect([rootDir]);
+
+    const all = await callTool(client, "scan");
+    const filtered = await callTool(client, "scan", {
+      category: "foundation",
+    });
+    const allActionables = (all.payload as { actionables: unknown[] })
+      .actionables;
+    const filteredActionables = (
+      filtered.payload as { actionables: { category: string }[] }
+    ).actionables;
+
+    expect(filteredActionables.length).toBeLessThan(allActionables.length);
+    expect(
+      filteredActionables.every((entry) => entry.category === "foundation")
+    ).toBe(true);
+  });
+
+  it("returns full findings with roasts stripped when asked", async () => {
+    const rootDir = await createWorkspaceFixture({
+      kind: "none",
+      packages: [{ path: ".", preset: "next" }],
+    });
+    const { client } = await connect([rootDir]);
+
+    const { payload } = await callTool(client, "scan", { full: true });
+    const findings = (payload as { findings: { roast: string | null }[] })
+      .findings;
+
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings.every((finding) => finding.roast === null)).toBe(true);
+  });
+
+  it("rejects paths outside the configured roots", async () => {
+    const rootDir = await createWorkspaceFixture({
+      kind: "none",
+      packages: [{ path: ".", preset: "next" }],
+    });
+    const { client } = await connect([rootDir]);
+
+    const escaped = await callTool(client, "scan", { path: "../.." });
+    const absolute = await callTool(client, "scan", { path: "/etc" });
+
+    expect(escaped.isError).toBe(true);
+    expect(escaped.text).toMatch(OUTSIDE_ROOTS_PATTERN);
+    expect(absolute.isError).toBe(true);
+  });
+
+  it("returns identical bodies for identical calls", async () => {
+    const rootDir = await createWorkspaceFixture({
+      kind: "none",
+      packages: [{ path: ".", preset: "next" }],
+    });
+    const { client } = await connect([rootDir]);
+
+    const first = await callTool(client, "scan");
+    const second = await callTool(client, "scan");
+
+    expect(second.text).toBe(first.text);
+  });
+
+  it("lists workspace projects with classifications", async () => {
+    const rootDir = await createWorkspaceFixture({
+      packages: [
+        { path: "apps/web", preset: "next" },
+        { path: "packages/ui", preset: "library" },
+      ],
+    });
+    const { client } = await connect([rootDir]);
+
+    const { payload } = await callTool(client, "list_projects");
+    const result = payload as {
+      kind: string;
+      projects: { kind: string; packageDir: string }[];
+    };
+
+    expect(result.kind).toBe("pnpm");
+    expect(result.projects.map((project) => project.packageDir)).toEqual([
+      "apps/web",
+      "packages/ui",
+    ]);
+    expect(result.projects[0]?.kind).toBe("application");
+    expect(result.projects[1]?.kind).toBe("library");
+  });
+
+  it("filters a workspace scan by packageDir and names unknown ones", async () => {
+    const rootDir = await createWorkspaceFixture({
+      packages: [
+        { path: "apps/web", preset: "next" },
+        { path: "apps/admin", preset: "vite" },
+      ],
+    });
+    const { client } = await connect([rootDir]);
+
+    const filtered = await callTool(client, "scan", {
+      packageDir: "apps/web",
+    });
+    const filteredResult = filtered.payload as {
+      actionables: { packageDir: string }[];
+      workspace: { applicationCount: number };
+    };
+
+    expect(filtered.isError).toBe(false);
+    expect(filteredResult.workspace.applicationCount).toBe(2);
+    expect(
+      filteredResult.actionables.every(
+        (entry) => entry.packageDir === "apps/web"
+      )
+    ).toBe(true);
+
+    const unknown = await callTool(client, "scan", { packageDir: "apps/nope" });
+    expect(unknown.isError).toBe(true);
+    expect(unknown.text).toContain("apps/web");
+  });
+
+  it("explains a rule and suggests near misses for unknown ids", async () => {
+    const rootDir = await createWorkspaceFixture({
+      kind: "none",
+      packages: [{ path: ".", preset: "next" }],
+    });
+    const { client } = await connect([rootDir]);
+
+    const known = await callTool(client, "explain_rule", {
+      ruleId: "theme-provider-configured",
+    });
+    const knownResult = known.payload as { category: string; id: string };
+
+    expect(known.isError).toBe(false);
+    expect(knownResult.id).toBe("theme-provider-configured");
+    expect(knownResult.category).toBe("foundation");
+
+    const unknown = await callTool(client, "explain_rule", {
+      ruleId: "theme-provider",
+    });
+    expect(unknown.isError).toBe(true);
+    expect(unknown.text).toContain("theme-provider-configured");
+  });
+});

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -22,7 +22,20 @@ export default defineConfig([
     },
     esbuildOptions: configureEsbuild,
     format: ["esm"],
-    noExternal: ["commander"],
+    // The MCP SDK (and the validator family its server core imports) is a
+    // devDependency bundled into dist, mirroring commander: users install
+    // six runtime deps, not an HTTP stack. cli:smoke audits the emitted
+    // bundle for the SDK's HTTP-transport modules.
+    noExternal: [
+      "commander",
+      /^@modelcontextprotocol\/sdk/,
+      "ajv",
+      "ajv-formats",
+      "json-schema-typed",
+      "zod-to-json-schema",
+      "eventsource-parser",
+      "content-type",
+    ],
     platform: "node",
     sourcemap: true,
     splitting: false,

--- a/plans/018-mcp-server.md
+++ b/plans/018-mcp-server.md
@@ -1,0 +1,264 @@
+# Plan 018: An MCP server inside the CLI
+
+> **Executor instructions**: This plan adds `shadscan mcp` — a stdio MCP
+> server so coding agents can query audit results as typed tool calls
+> instead of parsing a 59-finding dump. It ships inside `@shadscan/cli`
+> (no new package), re-scans on every call (never caches), and is
+> read-only by construction. It changes the CLI's public API (new
+> exports) but **not** the report schema or any rule; it ships as the
+> next minor. Docs are a phase of their own with named deliverables, not
+> an afterthought. Update `plans/README.md` when complete.
+>
+> **Drift check (run first)**:
+> `grep -rn "mcp" packages/cli/src/cli.ts packages/cli/package.json`
+> If an mcp subcommand exists, reconcile against what shipped.
+
+## Status
+
+- **State**: PLANNED
+- **Priority**: P1 — requested by a user, and it opens shadscan to agents
+  that cannot run arbitrary shell commands at all.
+- **Effort**: L
+- **Risk**: MEDIUM. The protocol work is small; the two real hazards are
+  the dependency (the MCP SDK drags an HTTP stack the CLI must not ship)
+  and stdout discipline (JSON-RPC owns stdout; one stray write corrupts
+  the session).
+- **Depends on**: none (0.8.0's publish state does not block this)
+- **Category**: cli/feature
+- **Planned at**: 2026-08-05
+
+## Why build it — and why NOT the reason that prompted it
+
+The requesting user's framing was "the agent could query what's still
+broken instead of re-scanning every time." That premise was measured and
+does not hold: a scan of this repository takes **~900ms**, and shadscan
+is deterministic over *file state* — the moment an agent edits a file,
+any cached answer is wrong, precisely when the agent most needs truth. A
+server that answered "what's still broken" from memory would confidently
+report stale failures.
+
+The real wins are different:
+
+1. **Context economy.** An agent fixing accessibility in `apps/web`
+   wants three typed actionables, not a 59-rule report to parse and
+   carry in context. Filtered, structured responses are the product.
+2. **Distribution.** Agents without shell access (or without approval to
+   run `npx`) cannot use shadscan today. MCP is the only door in.
+3. **The loop.** Fix → call `scan` → see the delta. Cheap because scans
+   are cheap; correct because every call re-scans.
+
+Therefore the design law: **every tool call runs a fresh scan. The
+server holds no result state.** "Incremental scanning" (what changed
+from these three files) would be genuinely faster *and* correct, but it
+is an engine project — the render graph makes one edited component
+invalidate every surface that renders it — and is explicitly out of
+scope here.
+
+## Current State (verified 2026-08-05)
+
+- The CLI's public API (`packages/cli/src/index.ts`) already exports
+  `scanProject`, `AuditReportSchema`, `RULE_CATALOG` (id, title,
+  description, category, adapters, confidence per rule), and every type
+  the server needs. **`scanWorkspace` and `discoverWorkspace` are not
+  exported yet** — the mcp subcommand imports internally, but exporting
+  them is part of this plan so the API tells the truth.
+- `agentHandoff.actionables` already carries the ideal response shape:
+  `disposition`, `priority`, `scoreImpact`, `packageDir`,
+  `suggestedFix`, `acceptanceCriteria`, `evidence`.
+- Scan timings, measured: ~900ms (this repo), ~3s (`shadcn-ui/ui`, 11
+  apps), ~23s (`dub`'s `apps/web`). Re-scan-per-call is viable; the
+  worst case informs the timeout guidance in docs.
+- **`@modelcontextprotocol/sdk@1.30.0` dependencies, inspected**: ajv,
+  cors, **express**, **hono**, jose, eventsource, express-rate-limit,
+  and more — an HTTP server stack serving its streamable-HTTP transport,
+  which this stdio-only server never uses.
+- The CLI ships exactly six runtime dependencies, and `tsup.config.ts`
+  already bundles `commander` via `noExternal` as a devDependency — the
+  exact precedent to follow.
+- The 0.8.0 progress checklist writes to stderr and disables itself on
+  non-TTY streams; under MCP, stdout is protocol and stderr is visible
+  to the client as log noise, so the mcp path must not enable it.
+
+## Scope decision (read this first)
+
+### Inside the CLI, not a new package
+
+A separate `@shadscan/mcp` would mean a second publish pipeline, a
+second version to pin, a second entry in the release runbook, and a
+"which version of the CLI does my MCP server match" question forever.
+`shadscan mcp` means users who have the CLI already have the server, and
+one version describes both. Client configs point at the same package:
+`npx -y @shadscan/cli mcp`.
+
+### The SDK is bundled, never a runtime dependency
+
+Adding the MCP SDK to `dependencies` would put express/hono/jose into
+every `npx @shadscan/cli` install — unacceptable against the six-dep
+discipline. Instead:
+
+1. Add `@modelcontextprotocol/sdk` to **devDependencies**, import only
+   the stdio server entry points, and add it to `noExternal` so tsup
+   bundles the used modules.
+2. **Audit the emitted bundle** (this is a hard gate, not a hope): grep
+   `dist/cli.js` for `express`, `hono`, `jose`, `cors` — none may
+   appear; record the size delta of `dist/cli.js` in the PR (current:
+   ~768KB) and treat more than ~300KB of growth as a stop-and-report.
+3. **Fallback if the audit fails**: the stdio surface actually needed —
+   `initialize`, `tools/list`, `tools/call`, JSON-RPC 2.0 framing over
+   newline-delimited stdio — is small enough to hand-roll against the
+   spec. Prefer the SDK for protocol-drift safety; hand-roll only if
+   bundling drags the HTTP stack in.
+
+### Three tools, no more
+
+| Tool | Maps to | Returns |
+|---|---|---|
+| `scan` | `scanProject` / `scanWorkspace` | score, grade, and **actionables** (fail + advisory), filterable |
+| `list_projects` | `discoverWorkspace` | packages, kinds, classification reasons, skips — `--list-projects` as a tool |
+| `explain_rule` | `RULE_CATALOG` | one rule's title, description, category, adapters, confidence |
+
+`scan` input: `{ path?, category?, severity?, packageDir?, full? }`.
+The default response is the *compact* view — score, grade, counts, and
+actionables with `findingId`, `title`, `priority`, `scoreImpact`,
+`packageDir`, `suggestedFix`, and first evidence location. `full: true`
+returns complete findings for the (rare) agent that wants all 59.
+Every response carries `rulesetVersion`, `engineVersion`, and
+`schemaVersion`, because two agents comparing results across versions
+deserve to know they differ.
+
+**Deliberately absent**: any fix/write tool (read-only is a security
+property worth advertising, not a gap), any caching tool, any
+"remaining work" state, prompts/resources (tools only, first release).
+
+### Security posture
+
+- **Roots are fixed at launch**: `shadscan mcp [path...]` (default: the
+  launch cwd). Tool calls with a `path` outside every root are rejected
+  with a stable error — reuse the `filesystemRoot` boundary the scanner
+  already enforces, do not invent a second check.
+- Read-only; no shell, no network, no file writes.
+- `stripRoasts` on all MCP output — an agent quoting a roast into a
+  commit message is nobody's good day.
+- Evidence paths stay project-relative (already guaranteed by
+  `normalizeFindingPaths`); the server must not leak absolute scanner
+  paths in errors either — match the CLI's existing redacted-error
+  discipline in `cli-error.ts`.
+
+### Schema-consumer cost, stated
+
+This makes MCP the **fourth** consumer of the report shape (CLI, hosted
+API, GitHub Action, MCP). Mitigation: MCP responses are derived
+*subsets* validated by their own zod schemas at the boundary, so a
+future schema bump fails loudly in one file (`mcp-contracts.ts`) rather
+than silently changing tool output.
+
+## Phase 1 — Transport, `scan` tool, stdout discipline
+
+1. `packages/cli/src/mcp/server.ts` (server wiring + stdio transport)
+   and `packages/cli/src/mcp/tools.ts` (tool handlers, pure functions
+   over the public scan API). Register `mcp` as a commander subcommand
+   that bypasses `runScanAction` entirely — no progress, no post-scan
+   menu, no banner. stdout carries JSON-RPC only; startup diagnostics go
+   to stderr once, then silence.
+2. `scan` tool with filters, compact/full modes, and the version triplet
+   on every response. Workspace-vs-single routing mirrors `cli.ts`
+   exactly (lone package at the root → single-package path), by calling
+   the same exported functions — not by copying the logic.
+3. Export `scanWorkspace` and `discoverWorkspace` from `index.ts`.
+4. The bundle audit from the scope decision, wired into `cli:smoke` so
+   it cannot regress silently: pack, grep the tarball's `dist/cli.js`
+   for the forbidden modules, fail loudly.
+
+**Tests** (vitest, SDK `InMemoryTransport` — no subprocess needed):
+initialize handshake; `tools/list` shape; `scan` on a Next fixture
+returns actionables and score; `category`/`severity` filters narrow
+results; `path` outside the root rejected with the stable message;
+`full: true` returns findings; two identical calls return identical
+bodies (determinism is the brand — prove it over MCP too).
+
+## Phase 2 — Workspace and rules tools
+
+1. `list_projects` (packages, kinds, kindReasons, skips, truncation —
+   the same data `--list-projects` prints).
+2. `scan` with `packageDir` filtering pooled results; error message
+   names the available `packageDir`s when the filter matches nothing.
+3. `explain_rule` from `RULE_CATALOG`; unknown ids return the five
+   nearest ids by prefix rather than a bare error, because agents
+   habitually guess `kebab-case` names.
+4. Response-size guard: compact scan responses over ~50 actionables get
+   summarized counts by category plus the top 20 by `scoreImpact`, with
+   a note saying so — silent truncation reads as "that's everything."
+
+**Tests**: monorepo fixture (reuse `createWorkspaceFixture`) through
+`list_projects` and filtered `scan`; nearest-id suggestions; the size
+guard's note appears.
+
+## Phase 3 — Hardening and the packed smoke test
+
+1. A real subprocess smoke: spawn the **packed** CLI (`npm pack` output,
+   as `cli:smoke` already does), drive `initialize` → `tools/list` →
+   `scan` over actual stdio, assert clean JSON-RPC framing end to end.
+   This is the test that catches a stray `console.log` from a dependency
+   three levels down, which `InMemoryTransport` never will.
+2. Signal handling: SIGINT/SIGTERM exit cleanly mid-scan (the abort
+   plumbing from `ScanOptions.signal` already exists — wire it to
+   transport close).
+3. Concurrent `tools/call` requests: serialize scans (the parsed-file
+   caches are per-project and memory-heavy; two simultaneous scans of a
+   large repo is an OOM invitation). Document the serialization.
+
+## Phase 4 — Documentation (deliverables, each named)
+
+1. **`docs/mcp.md`** — the runbook. Contents: what the server is and the
+   re-scan-every-call contract stated plainly; setup for **Claude Code**
+   (`claude mcp add shadscan -- npx -y @shadscan/cli mcp`), **Cursor**,
+   **VS Code**, and generic JSON config (command `npx`, args
+   `["-y", "@shadscan/cli", "mcp", "<path>"]`); the three tools with
+   input/output examples copied from real runs, not invented; the
+   security posture (roots, read-only, redacted errors); timeout
+   guidance ("large monorepos can take ~30s — raise client timeouts");
+   troubleshooting (the #1 will be "path outside root").
+2. **`README.md`** — an "MCP server" section after the Agent Handoff
+   section: the one-line Claude Code setup, the three tools in a
+   sentence each, link to `docs/mcp.md`. Version pins in examples follow
+   the existing rule (unqualified `@shadscan/cli`;
+   `verify-version-pins.mjs` must stay green).
+3. **Site docs page** (`app/docs/page.tsx`): an `#mcp-server` section
+   mirroring the README content in the page's voice, added to
+   `DOCS_SECTIONS` in `lib/docs-sections.ts` so ⌘K finds it — slotted
+   after "Agent skill", which is its natural neighbor.
+4. **`docs/cli-contract.md`** — the contract addition: under `mcp`,
+   stdout is JSON-RPC exclusively; stderr carries at most one startup
+   line and abnormal-exit diagnostics; all other output contracts
+   (JSON/human/prompt) unchanged.
+5. **`CHANGELOG.md`** — Unreleased → Added, including the user-visible
+   sentence about what the server refuses to do (cache, write, roast).
+6. **`packages/cli/README.md`** — mirror the root README section (it
+   ships in the npm tarball and is what npmjs.com renders).
+
+## Release
+
+Ships as the next **minor** (0.9.0 if 0.8.0 has been published by then;
+renumber accordingly if not). No ruleset bump — no rule behavior
+changes. No schema bump — the report shape is unchanged; MCP responses
+are derived views. Full 14-gate suite; the publish remains owner-held.
+
+## Open Questions / Risks
+
+1. **The bundle audit is the make-or-break.** If tsup cannot keep
+   express/hono out of `dist/cli.js`, fall back to hand-rolled stdio
+   JSON-RPC rather than shipping an HTTP stack to every CLI user. Do not
+   soften this into "acceptable for now."
+2. **SDK protocol churn.** MCP is young; pin the SDK exactly (the repo
+   pins everything exactly already) and record the protocol version the
+   server advertises in `docs/mcp.md`.
+3. **Long scans vs client timeouts.** `dub` took 23s; some MCP clients
+   default to 30–60s tool timeouts. Documented, plus the serialized-scan
+   note; if it bites in practice, MCP progress notifications are the
+   follow-up, not pre-built complexity.
+4. **Per-call cost on giant repos.** Re-scan-per-call is a deliberate
+   correctness choice; if a real user hits pain, the fix is incremental
+   scanning (its own engine plan), not MCP-side caching. This plan's
+   answer must stay "correct and 1–30s", never "instant and stale."
+5. **Tool naming collisions.** `scan` is generic; clients namespace by
+   server (`shadscan.scan`), so keep the short names.

--- a/plans/README.md
+++ b/plans/README.md
@@ -20,7 +20,8 @@ the executor. Each plan is marked DONE with its landing commit when complete.
 | [014](014-monorepo-workspace-scanning.md) | Monorepo workspace scanning and pooled scoring | P1 | XL | - | DONE |
 | [015](015-interactive-scan-progress.md) | Interactive scan progress checklist | P1 | M | - | DONE (`56a3dfc`, `579afad`, `0cf5b45`) |
 | [016](016-children-transparent-wrappers.md) | See through children-transparent wrappers | P1 | L | - | PLANNED |
-| [017](017-stats-page.md) | /stats page: npm usage charted with Bklit | P2 | M | - | PLANNED |
+| [017](017-stats-page.md) | /stats page: npm usage charted with Bklit | P2 | M | - | DONE (`e2e0c51`) |
+| [018](018-mcp-server.md) | MCP server: typed audit tools for coding agents | P1 | L | - | PLANNED |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED | REJECTED
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
         specifier: 4.1.13
         version: 4.1.13
     devDependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.30.0
+        version: 1.30.0(zod@4.1.13)
       '@types/node':
         specifier: 18.19.130
         version: 18.19.130
@@ -1127,8 +1130,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -5150,7 +5153,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.26)
       ajv: 8.20.0
@@ -5169,6 +5172,28 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.1.13)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.26)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.26
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.1.13
+      zod-to-json-schema: 3.25.2(zod@4.1.13)
     transitivePeerDependencies:
       - supports-color
 
@@ -7835,7 +7860,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@dotenvx/dotenvx': 1.74.2
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.30.0(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.2
       commander: 14.0.3
@@ -8414,6 +8439,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.1.13):
+    dependencies:
+      zod: 4.1.13
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
Adds a stdio MCP server inside the CLI, so coding agents query audit results as typed tool calls instead of parsing a 59-finding dump — requested by a user, and it opens shadscan to agents that cannot run shell commands at all.

Implements [plan 018](plans/018-mcp-server.md).

## The design law: every call re-scans

The server holds no result state. The requesting user's framing was "query what's still broken instead of re-scanning" — measured and deliberately rejected: scans take ~900ms on a typical project, and shadscan is deterministic over *file state*, so a cached answer is wrong the moment an agent edits a file. The loop this ships is: fix → call `scan` → read the delta, correct every time.

## Three read-only tools

- **`scan`** — score, grade, and actionables (with `suggestedFix`, `acceptanceCriteria`, `scoreImpact`, first evidence location), filterable by `category`, `severity`, or `packageDir`; `full: true` for complete findings. Over 50 matches → keeps the top 20 by score impact **and says so** — never silent truncation.
- **`list_projects`** — workspace packages with application/library classification and reasons.
- **`explain_rule`** — one rule's contract; unknown ids answer with the nearest matching ids, since agents guess kebab-case names.

Every response carries `engineVersion`, `rulesetVersion`, `schemaVersion`.

Setup is one line: `claude mcp add shadscan -- npx -y @shadscan/cli mcp`

## The dependency problem, and how it's kept out of user installs

`@modelcontextprotocol/sdk` ships **express, hono, cors, jose** for its HTTP transports — which a stdio server never touches. It's a devDependency bundled via tsup `noExternal` (the existing `commander` pattern), so **the published package still installs exactly six runtime dependencies**. The packed smoke test now enforces this permanently: it greps the shipped `dist/cli.js` for the HTTP-stack import specifiers and fails loudly if any leak in.

**One deviation from the plan, reported rather than buried:** the bundle grew 786KB → 1.41MB (+623KB), past the plan's ~300KB stop-and-report line — the SDK's protocol core plus the ajv validator family it hard-requires. Accepted because the actual supply-chain concern (runtime dep count) is unchanged, the install is dominated by the 40MB `typescript` dependency regardless, and the alternative (hand-rolled JSON-RPC) trades ~600KB for permanent protocol-drift maintenance. The smoke test caps the bundle at 2.5MB so growth can't creep unnoticed.

## Security posture

Roots fixed at launch (`shadscan mcp <path>...`), out-of-root paths rejected with a stable message; read-only; roasts stripped from all responses; unexpected errors return the CLI's redacted messages. Scans are serialized — two simultaneous render-graph builds on a big repo compete for memory, not time.

## Verified where it counts

- 9 in-memory protocol tests (handshake, filters, root escape via `../..` and absolute paths, determinism of identical calls, workspace classification, near-miss rule suggestions).
- The packed smoke drives a **real** `initialize → tools/list → scan` over stdio against the tarball-installed binary and asserts **every stdout line parses as JSON-RPC** — the test that catches a stray `console.log` three dependencies down. Also verified by hand that error paths (nonexistent project) come back as proper `isError` tool results, not raw stream writes.
- All 12 gates green; self-audit 100/100 A.

## Docs (all six deliverables)

[`docs/mcp.md`](docs/mcp.md) runbook (Claude Code/Cursor/VS Code setup, tool reference with outputs captured from real runs, security posture, timeout guidance), README + `packages/cli/README` sections, `#mcp-server` on the site docs page with a ⌘K entry, `cli-contract.md` stdout discipline for mcp mode, and the changelog.

## Release

Next minor. No ruleset bump, no schema bump — MCP responses are derived views with their own boundary schemas in `mcp-contracts`, so a future report-schema change fails loudly in one file. Library API additionally exports `scanWorkspace`/`discoverWorkspace`.