### PR TITLE
fix(docs): correct the advertised rule count and gate it

### DIFF
--- a/.claude/skills/shadscan-release/SKILL.md
+++ b/.claude/skills/shadscan-release/SKILL.md
@@ -57,7 +57,24 @@ skill as the executable coordinator; never weaken or skip the runbook's gates.
 4. Verify the three versions agree: `packages/cli/package.json`,
    the new `CHANGELOG.md` heading, and the `changelog/<version>.md`
    frontmatter.
-5. Commit the preparation and push.
+5. Sweep the product surfaces that no generator owns. `pnpm docs:check`
+   catches the advertised version pins and rule counts, but run it now
+   rather than discovering it at gate time:
+   - **Advertised rule count** — both `README.md` and
+     `packages/cli/README.md` state the rule count in prose ("N rules",
+     "contains N deterministic checks"). A release that adds or removes a
+     rule must update all four. Never touch the counts in `CHANGELOG.md`
+     or `changelog/*.md`: those are historical records of what shipped
+     then, and rewriting them is falsifying the record.
+   - **Ruleset version** — `BUNDLED_RULESET_VERSION` in
+     `packages/cli/src/scan.ts` must already be bumped by whatever added
+     or changed a rule, and `docs/rules.md` regenerated with
+     `pnpm docs:rules`.
+   - **Hardcoded rule counts in tests** — `packages/cli/test/public-api.test.ts`
+     and `packages/cli/scripts/smoke-package.mjs` both assert
+     `RULE_CATALOG.length`. The smoke one fails late, after a full build
+     and npm pack, with a message that says nothing about rule counts.
+6. Commit the preparation and push.
 
 ## 2. Run every release gate
 
@@ -111,9 +128,22 @@ staged tarball and approves on npm with 2FA.
    Next.js, Vite React, and generic React fixture projects. Run one fixture
    twice and confirm the two reports are identical — determinism is the
    product promise.
-4. Verify the deployed site: `/changelog` shows the new entry, and the audit
-   badge/scoring flows still work (site examples stay pinned to `@next` or an
-   exact version during the RC window).
+4. Verify the deployed site:
+   - `/changelog` shows the new entry.
+   - `/stats` reflects the release. **Nothing on this page is edited by
+     hand** — every tile (`Latest`, `Versions`, `Downloads`, `Stars`) is
+     pulled live from the npm registry and the GitHub API, and the page
+     revalidates hourly (`export const revalidate = 3600`). So this is a
+     confirmation step, not an update step: after publishing, the `Latest`
+     tile should show the new version within the hour, and a new bar
+     should appear in the per-version chart. If it still shows the
+     previous version after the revalidate window, the publish did not
+     reach the registry — investigate rather than editing the page.
+   - `/rules` lists the new rule count; it reads
+     `lib/generated/rule-catalog.json`, so a wrong number there means the
+     catalog was not regenerated.
+   - The audit badge/scoring flows still work (site examples stay pinned to
+     `@next` or an exact version during the RC window).
 
 ## 5. Close out
 
@@ -126,6 +156,17 @@ staged tarball and approves on npm with 2FA.
   forward. Unpublish only for security or accidental disclosure, per policy.
 
 ## Hard-won rules
+
+- **Tag the release before publishing the next one.** Three releases
+  published before their Git tag existed (0.8.0, 0.9.0, 0.10.0), leaving no
+  commit to diff a shipped version against. `check-release.mjs` now fails
+  when the previous release in `CHANGELOG.md` has no matching tag and names
+  the command to fix it, but push the tag as part of the release rather than
+  waiting for the next one to complain.
+- **Prose counts go stale silently.** The rule count in both READMEs is not
+  owned by any generator. `pnpm docs:rules --check` now compares them against
+  `RULE_CATALOG.length`, which is why that gate exists — do not "fix" a
+  failure by editing the generated files.
 
 - Any new top-level file or directory in this repository must be added to
   `SCANNER_TRACE_EXCLUDES` in `next.config.ts`, or `pnpm build` fails in the

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="https://www.shadscan.com">Website</a> ·
   <a href="https://www.shadscan.com/scan">Scan a repository</a> ·
   <a href="https://www.shadscan.com/docs">Docs</a> ·
-  <a href="docs/rules.md">59 rules</a> ·
+  <a href="docs/rules.md">60 rules</a> ·
   <a href="https://www.shadscan.com/sponsors">Sponsor</a>
 </p>
 
@@ -202,7 +202,7 @@ files. Details and per-client setup live in [docs/mcp.md](docs/mcp.md).
 
 ## What It Checks
 
-The bundled ruleset contains 59 deterministic checks across six weighted
+The bundled ruleset contains 60 deterministic checks across six weighted
 categories.
 
 | Category | Examples |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,7 +16,7 @@
   <a href="https://www.shadscan.com">Website</a> &middot;
   <a href="https://www.shadscan.com/scan">Scan a repository</a> &middot;
   <a href="https://www.shadscan.com/docs">Docs</a> &middot;
-  <a href="https://www.shadscan.com/docs">59 rules</a> &middot;
+  <a href="https://www.shadscan.com/docs">60 rules</a> &middot;
   <a href="https://www.shadscan.com/sponsors">Sponsor</a>
 </p>
 
@@ -177,7 +177,7 @@ configure Git, or add a Husky or native pre-commit hook.
 
 ## What It Checks
 
-The bundled ruleset contains 59 deterministic checks across six weighted
+The bundled ruleset contains 60 deterministic checks across six weighted
 categories.
 
 | Category | Examples |

--- a/packages/cli/scripts/generate-rule-catalog.ts
+++ b/packages/cli/scripts/generate-rule-catalog.ts
@@ -13,6 +13,46 @@ const SITE_OUTPUT_PATH = fileURLToPath(
   new URL("../../../lib/generated/rule-catalog.json", import.meta.url)
 );
 
+/**
+ * Both READMEs advertise the rule count in prose, which no generator owns, so
+ * it silently went stale for several releases. Checked here because this is
+ * the one place that already knows the true count.
+ */
+const ADVERTISED_COUNT_READMES = [
+  {
+    label: "README.md",
+    path: fileURLToPath(new URL("../../../README.md", import.meta.url)),
+  },
+  {
+    label: "packages/cli/README.md",
+    path: fileURLToPath(new URL("../README.md", import.meta.url)),
+  },
+];
+const ADVERTISED_COUNT_PATTERNS = [
+  /(\d+) rules<\/a>/,
+  /The bundled ruleset contains (\d+) deterministic checks/,
+];
+
+const findStaleAdvertisedCounts = async (): Promise<string[]> => {
+  const stale: string[] = [];
+
+  for (const readme of ADVERTISED_COUNT_READMES) {
+    const content = await readFile(readme.path, "utf8").catch(() => "");
+
+    for (const pattern of ADVERTISED_COUNT_PATTERNS) {
+      const match = content.match(pattern);
+
+      if (match && Number(match[1]) !== RULE_CATALOG.length) {
+        stale.push(
+          `${readme.label} advertises ${match[1]} rules, expected ${RULE_CATALOG.length}`
+        );
+      }
+    }
+  }
+
+  return stale;
+};
+
 const CATEGORY_TITLES = {
   accessibility: "Accessibility",
   forms: "Forms and Data Entry",
@@ -103,6 +143,15 @@ const main = async (): Promise<void> => {
     if (staleOutputs.length > 0) {
       process.stderr.write(
         `${staleOutputs.join(", ")} ${staleOutputs.length === 1 ? "is" : "are"} stale. Run \`pnpm docs:rules\` and commit the result.\n`
+      );
+      process.exitCode = 1;
+    }
+
+    const staleCounts = await findStaleAdvertisedCounts();
+
+    if (staleCounts.length > 0) {
+      process.stderr.write(
+        `${staleCounts.join("\n")}\nUpdate the advertised rule counts by hand; no generator owns README prose.\n`
       );
       process.exitCode = 1;
     }


### PR DESCRIPTION
0.10.0 added the sixtieth rule, but both READMEs still advertised **59**. The count appears twice in each file — the header badge link and the scoring section — and no generator owns that prose, so it went stale silently.

## What was actually stale

| Surface | Was | Now |
|---|---|---|
| `README.md:19` (header link) | 59 rules | 60 rules |
| `README.md:205` (scoring section) | 59 deterministic checks | 60 |
| `packages/cli/README.md:19` | 59 rules | 60 rules |
| `packages/cli/README.md:180` | 59 deterministic checks | 60 |

**Deliberately not touched**: the counts in `CHANGELOG.md` and `changelog/0.1.0.md`. Those are historical records — 59 was correct at 0.1.0, and rewriting them would falsify what shipped.

## Gated so it cannot recur

`pnpm docs:rules --check` (already in `docs:check`) now also compares both READMEs against `RULE_CATALOG.length` and fails with the expected number. That's the one place that already knows the true count, so the check costs nothing.

Verified it actually fires by reverting a count and re-running:

```
README.md advertises 59 rules, expected 60
Update the advertised rule counts by hand; no generator owns README prose.
```

## About /stats

Worth stating plainly, because it changes what the release skill should say: **there is nothing on `/stats` to update.** Every tile — `Latest`, `Versions`, `Downloads`, `Stars` — is pulled live from the npm registry and the GitHub API at request time, with `export const revalidate = 3600`. It still shows 0.9.0 only because 0.10.0 has not been published yet; it will pick the new version up within the hour of publishing, with no code change.

So the skill now frames `/stats` as a **post-publish confirmation** rather than an edit: if the `Latest` tile still shows the previous version after the revalidate window, the publish did not reach the registry, and that is a real signal worth investigating rather than something to paper over by editing the page.

## Release skill updates

- **New step 5** in "Prepare the version and changelogs" — sweep the surfaces no generator owns: the four advertised rule counts, `BUNDLED_RULESET_VERSION`, and the two hardcoded `RULE_CATALOG.length` assertions in `public-api.test.ts` and `smoke-package.mjs` (the latter fails late, after a full build and npm pack, with a message that never mentions rule counts).
- **Expanded step 4** verification — `/changelog`, `/stats` (as above), and `/rules`, with what a wrong number on each actually indicates.
- **Two hard-won rules recorded** — the prose-count staleness, and the Git tag that has now been missed three releases running (0.8.0, 0.9.0, 0.10.0), which `check-release.mjs` gained a gate for in `21deb80`.

## Verification

6 gates green (`check`, `docs:check`, `typecheck`, `cli:test`, `test:web`, `build`). Self-audit 100/100 A.

Docs and skill only — no rule logic, no ruleset bump, no schema change. Safe to land before or after the 0.10.0 publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation to reflect the bundled ruleset increasing from 59 to 60 deterministic checks.
  * Added clearer ruleset navigation and descriptions across the main and CLI documentation.
  * Expanded release guidance to include documentation, ruleset, and published-artifact verification.

* **Quality Improvements**
  * Added automated validation to detect outdated README rule counts and generated documentation mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->