### PR TITLE
fix(rules): do not flag a lone control in a ButtonGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ stable releases published under `latest`.
     legitimately holds buttons, selects, separators and arbitrary wrappers,
     and radio, checkbox and submit inputs carry no offset ring, so none of
     those are reported.
+  - A group holding a single child is silent. `ButtonGroup` joins with
+    `[&>*:not(:first-child)]`, so a lone control is joined to nothing:
+    there is no seam and no ring to bisect. A conditional sibling still
+    counts, since `{loading ? <Spinner/> : <Button/>}` renders one either
+    way.
   - It ships advisory and does not affect scores. Burn-in across nine real
     shadcn projects found four instances and no false positives, but all nine
     share one author, so that is not yet an independent enough sample to

--- a/changelog/0.10.0.md
+++ b/changelog/0.10.0.md
@@ -60,7 +60,8 @@ in any real project we tested.
 It is deliberately quiet. `ButtonGroup` is an open container that legitimately
 holds buttons, selects, separators and arbitrary wrappers, and radio,
 checkbox and submit inputs carry no ring of their own. None of those are
-reported. Only text entry is.
+reported. Only text entry is — and only when something is actually joined to
+it, since a group holding one lone control has no seam to break.
 
 ## Advisory, on purpose
 

--- a/packages/cli/src/rules/button-group-holds-only-buttons.ts
+++ b/packages/cli/src/rules/button-group-holds-only-buttons.ts
@@ -1,7 +1,9 @@
 import {
   forEachChild,
   isJsxElement,
+  isJsxExpression,
   isJsxSelfClosingElement,
+  isJsxText,
   type JsxOpeningLikeElement,
   type Node,
 } from "typescript";
@@ -152,6 +154,31 @@ const findTextControl = (
   return hit;
 };
 
+/**
+ * How many direct children the group actually joins. ButtonGroup squares off
+ * corners and drops borders with `[&>*:not(:first-child)]`, so a group holding
+ * a single child joins nothing: there is no seam, and no ring to bisect. A
+ * conditional child counts, since `{loading ? <Spinner/> : <Button/>}` renders
+ * a sibling in either branch.
+ */
+const countJoinedChildren = (node: Node): number => {
+  if (!isJsxElement(node)) {
+    return 0;
+  }
+
+  return node.children.filter((child) => {
+    if (isJsxText(child)) {
+      return child.text.trim() !== "";
+    }
+
+    return (
+      isJsxElement(child) ||
+      isJsxSelfClosingElement(child) ||
+      isJsxExpression(child)
+    );
+  }).length;
+};
+
 const isButtonGroup = (node: Node, groupImports: UiModuleImports): boolean => {
   const element = getOpeningElement(node);
   const tagName = element ? getJsxTagName(element) : null;
@@ -188,7 +215,11 @@ const scanFile = (
   const visit = (node: Node): void => {
     if (isButtonGroup(node, groupImports)) {
       groupCount += 1;
-      violation ??= findTextControl(node, file, controls);
+
+      // Only a joined group can show the defect, so a lone child is silent.
+      if (countJoinedChildren(node) > 1) {
+        violation ??= findTextControl(node, file, controls);
+      }
     }
 
     forEachChild(node, visit);

--- a/packages/cli/test/button-group-holds-only-buttons.test.ts
+++ b/packages/cli/test/button-group-holds-only-buttons.test.ts
@@ -285,6 +285,62 @@ describe("button-group-holds-only-buttons", () => {
     expect(result.status).toBe("not-applicable");
   });
 
+  it("stays silent on a lone text control with nothing joined to it", async () => {
+    // ButtonGroup joins with [&>*:not(:first-child)], so a single child is
+    // joined to nothing: no seam, no bisected ring, nothing to report.
+    const fixture = await createShadcnFixture();
+    await fixture.write(
+      "src/lone.tsx",
+      `
+        import { ButtonGroup } from "@/components/ui/button-group";
+        import { Input } from "@/components/ui/input";
+
+        export function Lone() {
+          return (
+            <ButtonGroup>
+              <Input placeholder="Email" />
+            </ButtonGroup>
+          );
+        }
+      `
+    );
+
+    const result = await runRule(
+      fixture.rootDir,
+      buttonGroupHoldsOnlyButtonsRule
+    );
+
+    expect(result.status).toBe("pass");
+  });
+
+  it("still reports when the sibling is conditional", async () => {
+    const fixture = await createShadcnFixture();
+    await fixture.write(
+      "src/conditional.tsx",
+      `
+        import { Button } from "@/components/ui/button";
+        import { ButtonGroup } from "@/components/ui/button-group";
+        import { Input } from "@/components/ui/input";
+
+        export function Conditional({ loading }: { loading: boolean }) {
+          return (
+            <ButtonGroup>
+              <Input placeholder="Email" />
+              {loading ? <span>…</span> : <Button>Go</Button>}
+            </ButtonGroup>
+          );
+        }
+      `
+    );
+
+    const result = await runRule(
+      fixture.rootDir,
+      buttonGroupHoldsOnlyButtonsRule
+    );
+
+    expect(result.status).toBe("advisory");
+  });
+
   it("never moves the score while it ships advisory", () => {
     // Promotion must change maxScore, confidence and the result helper
     // together; a fail() left at confidence "low" is silently downgraded back


### PR DESCRIPTION
`button-group-holds-only-buttons` reported a text control inside **any** `ButtonGroup`, including one holding nothing else. That's a false positive.

`ButtonGroup` joins its children with `[&>*:not(:first-child)]:rounded-l-none` and `border-l-0`. With a single child those selectors never match — no squared corner, no dropped border, no seam, and therefore no ring to bisect. There is nothing to report.

```tsx
// Reported before this fix. Nothing is joined; nothing is wrong.
<ButtonGroup>
  <Input placeholder="Email" />
</ButtonGroup>
```

## The fix

Report only when the group has more than one meaningful direct child. A conditional child counts — `{loading ? <Spinner/> : <Button/>}` renders a sibling either way — so the common loading-state shape still reports.

## How it was found, and what that says about the burn-in

Not by the burn-in. By the question *"this rule is only when there are button and input right?"* — which I could have answered from memory and got wrong, so I probed it instead and the probe came back `advisory`.

The original burn-in ran across nine projects and found no false positives, which I reported as a property of the rule. It was a property of **that sample**: none of the nine contained a lone-control `ButtonGroup`. Worth stating plainly, because the same caveat still applies to what's left — nine projects, one author.

## Verification

- 12 tests (2 new): the lone control now passes; a conditional sibling still reports.
- Burn-in re-run after the fix — **the same four true positives still report** (`orcdev`, `github-creature`, `star-history`, `youtubetoblog`) and **the same five stay silent**. The fix narrowed the rule without blunting it.
- 7 gates green including `cli:smoke`. Self-audit 100/100 A.

## Release handling

Folded into **0.10.0** rather than shipped as a follow-up: 0.10.0 is prepared but **not yet published to npm**, so the rule has not reached anyone. The alternative — publishing a known false positive and fixing it in 0.10.1 — would be strictly worse. Both changelog entries updated to describe the lone-child exclusion as part of the rule's contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented false warnings for `ButtonGroup` components containing only one rendered child.
  - Conditional siblings are correctly recognized when determining whether controls are joined.
  - Text inputs now report only when joined to another control, avoiding warnings for standalone controls.

- **Documentation**
  - Updated changelogs to document the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->