### PR TITLE
fix(stats): stop plotting days npm has not settled

### DIFF
--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -137,9 +137,9 @@ export default async function StatsPage() {
                 Downloads per day
               </h2>
               <p className="text-muted-foreground text-sm">
-                Every complete day since the first release. npm settles a
-                day&apos;s total a few hours after it closes, so today is not
-                plotted.
+                Every settled day since the first release. npm fills a
+                day&apos;s total in some hours after it closes, so the most
+                recent day or two arrive late rather than at zero.
               </p>
             </div>
             {stats.daily.length > 0 ? (

--- a/lib/npm-stats.ts
+++ b/lib/npm-stats.ts
@@ -62,6 +62,30 @@ const toIsoDay = (value: Date): string =>
 const getLastCompleteDay = (now: Date): string =>
   toIsoDay(new Date(now.getTime() - DAY_MS));
 
+/**
+ * Asking for a day npm has not settled yet returns `0` rather than an error or
+ * a partial count, which is indistinguishable from a real zero and renders as
+ * a cliff to the floor at the right edge — exactly the shape that reads as
+ * "nobody uses this". In practice the lag runs past the 24 hours
+ * `getLastCompleteDay` allows for.
+ *
+ * Trailing zeros are therefore dropped rather than plotted. Only the tail is
+ * trimmed: an interior zero is a real quiet day and stays. A series that is
+ * zero throughout belongs to a package nobody has downloaded yet, so it is
+ * returned untouched rather than emptied.
+ */
+const dropUnsettledTrailingDays = (
+  days: readonly DownloadDay[]
+): DownloadDay[] => {
+  let end = days.length;
+
+  while (end > 0 && days[end - 1]?.downloads === 0) {
+    end -= 1;
+  }
+
+  return end === 0 ? [...days] : days.slice(0, end);
+};
+
 const isIsoDay = (value: unknown): value is string =>
   typeof value === "string" && ISO_DAY_PATTERN.test(value);
 
@@ -295,7 +319,9 @@ const fetchNpmStats = async (
     ),
   ]);
 
-  const daily = parseDownloadRange(rangePayload) ?? [];
+  const daily = dropUnsettledTrailingDays(
+    parseDownloadRange(rangePayload) ?? []
+  );
   const versions = parseVersionDownloads(versionsPayload) ?? [];
 
   return {

--- a/test/shadscan-web/npm-stats.test.ts
+++ b/test/shadscan-web/npm-stats.test.ts
@@ -181,6 +181,72 @@ describe("fetchNpmStats", () => {
     expect(calls.some((url) => url.includes("@shadscan%2Fcli"))).toBe(true);
   });
 
+  it("drops trailing days npm has not settled yet", async () => {
+    // npm answers 0 for a day it has not filled in, which is indistinguishable
+    // from a real zero and plots as a cliff to the floor at the right edge.
+    const { fetchImplementation } = createFetch({
+      ...ALL_ROUTES,
+      "/downloads/range/": {
+        downloads: [
+          { day: "2026-07-27", downloads: 1194 },
+          { day: "2026-07-28", downloads: 1611 },
+          { day: "2026-07-29", downloads: 0 },
+          { day: "2026-07-30", downloads: 0 },
+        ],
+        end: "2026-07-30",
+        package: "@shadscan/cli",
+        start: "2026-07-27",
+      },
+    });
+    const stats = await fetchNpmStats(NOW, fetchImplementation);
+
+    expect(stats?.daily.map((entry) => entry.day)).toEqual([
+      "2026-07-27",
+      "2026-07-28",
+    ]);
+    // The dropped days must not be counted either.
+    expect(stats?.totalDownloads).toBe(2805);
+  });
+
+  it("keeps an interior zero, which is a real quiet day", async () => {
+    const { fetchImplementation } = createFetch({
+      ...ALL_ROUTES,
+      "/downloads/range/": {
+        downloads: [
+          { day: "2026-07-27", downloads: 1194 },
+          { day: "2026-07-28", downloads: 0 },
+          { day: "2026-07-29", downloads: 1611 },
+        ],
+        end: "2026-07-29",
+        package: "@shadscan/cli",
+        start: "2026-07-27",
+      },
+    });
+    const stats = await fetchNpmStats(NOW, fetchImplementation);
+
+    expect(stats?.daily).toHaveLength(3);
+    expect(stats?.daily[1]?.downloads).toBe(0);
+  });
+
+  it("keeps an all-zero series rather than emptying the chart", async () => {
+    // A package nobody has downloaded yet still deserves its axis.
+    const { fetchImplementation } = createFetch({
+      ...ALL_ROUTES,
+      "/downloads/range/": {
+        downloads: [
+          { day: "2026-07-27", downloads: 0 },
+          { day: "2026-07-28", downloads: 0 },
+        ],
+        end: "2026-07-28",
+        package: "@shadscan/cli",
+        start: "2026-07-27",
+      },
+    });
+    const stats = await fetchNpmStats(NOW, fetchImplementation);
+
+    expect(stats?.daily).toHaveLength(2);
+  });
+
   it("returns null when the registry is unavailable", async () => {
     const { fetchImplementation } = createFetch(ALL_ROUTES, {
       "registry.npmjs.org": 500,


### PR DESCRIPTION
The downloads chart ended in a cliff to zero, which reads as "nobody uses this" rather than "the data hasn't landed yet".

## Root cause

npm answers **`0`** for a day it hasn't settled — not a partial count, not an error, not a gap. `getLastCompleteDay` backs off only 24 hours, but npm's lag runs past that, so the most recent day got plotted at zero and dragged the line to the floor.

Measured against the live registry:

```
2026-08-01    547
2026-08-02   1401
2026-08-03   1611
2026-08-04      0   <- unsettled, not a real zero
2026-08-05      0   <- unsettled (today)
```

The chart's own caption said *"today is not plotted"* — but Aug 4 **was** plotted, at zero. The copy and the behaviour disagreed, and the copy was right about intent.

## Why not a dashed line

That was the ask, and I went a different way — worth explaining, because it changes the outcome rather than the styling.

A dashed segment communicates "provisional", which needs a provisional *value* to draw. npm gives no partial count for an unsettled day; it gives `0`. So a dashed line would still plunge to the floor — same misleading shape, now with a texture on it. It wouldn't fix the thing that prompted the request.

Dropping the unsettled days removes the cliff outright, and matches what the caption already promised.

## The fix

`dropUnsettledTrailingDays` trims zero-download days from the **end** of the series only:

- an **interior** zero is a real quiet day and stays
- an **all-zero** series is returned untouched, so a package nobody has downloaded yet still gets an axis rather than an empty chart
- trimmed days are excluded from `totalDownloads` too (no-op arithmetically, but it keeps the series and the total describing the same set of days)

Caption updated: it now describes the settlement lag instead of asserting a fixed one-day rule it wasn't honouring.

## Verification

- 3 new tests: trailing zeros dropped, interior zero kept, all-zero series preserved. 174 web tests pass.
- **Against the live npm API**, series now ends `2026-08-03 → 1611` instead of `2026-08-05 → 0`.
- Rendered `/stats` locally and confirmed the right edge now rises instead of crashing, and that the new caption reads correctly.
- 8 gates green. Self-audit 100/100 A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily download statistics by excluding unsettled trailing days from totals.
  * Preserved valid zero-download days within the reporting period.
  * Clarified that the latest one or two days may appear later once npm settles the data.

* **Tests**
  * Added coverage for trailing zero days, interior zero days, and all-zero download series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->