### PR TITLE
feat(stats): report the ruleset on the stats page

### DIFF
--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -3,6 +3,7 @@ import {
   VersionDownloadsChart,
 } from "@/components/stats-charts";
 import { Separator } from "@/components/ui/separator";
+import catalog from "@/lib/generated/rule-catalog.json";
 import { getNpmStats, PACKAGE_NAME } from "@/lib/npm-stats";
 import { getHeaderGitHubRepository } from "@/lib/public-github-repository";
 import { createPageMetadata } from "@/lib/site-metadata";
@@ -83,8 +84,9 @@ export default async function StatsPage() {
           <code className="rounded-none bg-muted px-1.5 py-0.5 text-sm">
             {PACKAGE_NAME}
           </code>
-          , pulled from the npm registry. Counts include continuous integration
-          and mirrors, so they measure downloads rather than people.
+          , pulled from the npm registry, alongside the size of the bundled
+          ruleset. Download counts include continuous integration and mirrors,
+          so they measure downloads rather than people.
         </p>
       </header>
 
@@ -96,7 +98,7 @@ export default async function StatsPage() {
         <div className="flex flex-col gap-12">
           <section className="flex flex-col gap-4">
             <h2 className="sr-only">Summary</h2>
-            <dl className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+            <dl className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
               <StatTile
                 detail={`since ${DAY_FORMAT.format(new Date(`${stats.firstPublishedDay}T00:00:00Z`))}`}
                 label="Downloads"
@@ -124,6 +126,11 @@ export default async function StatsPage() {
                 value={EXACT.format(stats.versionCount)}
               />
               <StatTile
+                detail={`ruleset ${catalog.rulesetVersion}`}
+                label="Rules"
+                value={EXACT.format(catalog.rules.length)}
+              />
+              <StatTile
                 label="Stars"
                 title={EXACT.format(repository.stargazersCount)}
                 value={COMPACT.format(repository.stargazersCount)}
@@ -143,7 +150,9 @@ export default async function StatsPage() {
               </p>
             </div>
             {stats.daily.length > 0 ? (
-              <DailyDownloadsChart data={stats.daily} />
+              <div className="-mx-4 overflow-x-auto px-4 sm:mx-0 sm:px-0">
+                <DailyDownloadsChart data={stats.daily} />
+              </div>
             ) : (
               <StatsUnavailable />
             )}
@@ -162,7 +171,9 @@ export default async function StatsPage() {
             </div>
             {stats.versions.length > 0 ? (
               <>
-                <VersionDownloadsChart data={stats.versions} />
+                <div className="-mx-4 overflow-x-auto px-4 sm:mx-0 sm:px-0">
+                  <VersionDownloadsChart data={stats.versions} />
+                </div>
                 <table className="w-full text-sm">
                   <caption className="sr-only">
                     Downloads per version over the last 7 days


### PR DESCRIPTION
The stats page tracked npm-shaped numbers — downloads, versions, stars — and said **nothing about the engine**. Zero mentions of rules, which is both the number that changes every release and the one thing shadscan is actually about.

## The Rules tile

Reads the count and ruleset version straight from `lib/generated/rule-catalog.json`:

```
Rules
61
ruleset 2026.07.43
```

It can't drift. That catalog is regenerated by `pnpm docs:rules` and already enforced by `docs:check`, so landing a rule advances this tile with no one remembering to.

This is the honest answer to "the stats page wasn't updated for the release". Every *existing* value there is pulled live from the npm registry and the GitHub API on an hourly revalidate and has never been hand-edited — I verified that across `page.tsx`, `opengraph-image.tsx`, `stats-social-copy.ts`, `npm-stats.ts` and `stats-charts.tsx`. What was missing wasn't a stale number; it was a missing one.

## A mobile overflow fixed on the way

At 320px the page body scrolled sideways: the chart SVG rendered **848px** wide against a 320px viewport. The tile grid was never the problem (288px, comfortably inside), and the overflow predates this change.

Charts now sit in their own `overflow-x-auto` container. Measured after the fix: `bodyScrollWidth === clientWidth === 320`, no body overflow — and the charts reflow to fit rather than needing to scroll at all, once given a bounded container.

Worth noting shadscan's own `mobile-overflow-absent` rule did not catch this, because the width only exists at runtime in rendered SVG. Not a rule bug, but a real limit of static analysis worth knowing.

## Verification

- Rendered at desktop and at 320px, dark mode, and measured overflow before and after rather than eyeballing it.
- 8 gates green. Self-audit 100/100 A against the published 0.11.0.

Site-only — no rule logic, no ruleset bump, no schema change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Rules tile to the stats page showing the catalog version and total rule count.
  * Updated summary information to include bundled ruleset size alongside npm downloads.

* **Style**
  * Expanded the summary grid to six columns.
  * Improved chart layouts on narrow screens with horizontal scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->