### PR TITLE
feat(stats): drop the per-version breakdown

### DIFF
--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,7 +1,4 @@
-import {
-  DailyDownloadsChart,
-  VersionDownloadsChart,
-} from "@/components/stats-charts";
+import { DailyDownloadsChart } from "@/components/stats-charts";
 import { Separator } from "@/components/ui/separator";
 import catalog from "@/lib/generated/rule-catalog.json";
 import { getNpmStats, PACKAGE_NAME } from "@/lib/npm-stats";
@@ -153,61 +150,6 @@ export default async function StatsPage() {
               <div className="-mx-4 overflow-x-auto px-4 sm:mx-0 sm:px-0">
                 <DailyDownloadsChart data={stats.daily} />
               </div>
-            ) : (
-              <StatsUnavailable />
-            )}
-          </section>
-
-          <section className="flex flex-col gap-4">
-            <div className="flex flex-col gap-1">
-              <h2 className="font-heading font-semibold text-xl tracking-tight">
-                Which versions people run
-              </h2>
-              <p className="text-muted-foreground text-sm">
-                A snapshot of the last 7 days, not a trend — npm publishes no
-                per-version history. Prereleases and older versions are grouped
-                as “other”.
-              </p>
-            </div>
-            {stats.versions.length > 0 ? (
-              <>
-                <div className="-mx-4 overflow-x-auto px-4 sm:mx-0 sm:px-0">
-                  <VersionDownloadsChart data={stats.versions} />
-                </div>
-                <table className="w-full text-sm">
-                  <caption className="sr-only">
-                    Downloads per version over the last 7 days
-                  </caption>
-                  <thead>
-                    <tr className="border-border border-b text-muted-foreground">
-                      <th className="py-2 text-left font-medium" scope="col">
-                        Version
-                      </th>
-                      <th className="py-2 text-right font-medium" scope="col">
-                        Downloads
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {stats.versions.map((entry) => (
-                      <tr
-                        className="border-border/60 border-b"
-                        key={entry.version}
-                      >
-                        <th
-                          className="py-2 text-left font-normal tabular-nums"
-                          scope="row"
-                        >
-                          {entry.version}
-                        </th>
-                        <td className="py-2 text-right tabular-nums">
-                          {EXACT.format(entry.downloads)}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </>
             ) : (
               <StatsUnavailable />
             )}

--- a/components/stats-charts.tsx
+++ b/components/stats-charts.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import { Area, AreaChart } from "@/components/charts/area-chart";
-import { Bar } from "@/components/charts/bar";
-import { BarChart } from "@/components/charts/bar-chart";
-import { BarXAxis } from "@/components/charts/bar-x-axis";
 import { Grid } from "@/components/charts/grid";
 import { ChartTooltip } from "@/components/charts/tooltip";
 import { XAxis } from "@/components/charts/x-axis";
-import type { DownloadDay, VersionDownloads } from "@/lib/npm-stats";
+import type { DownloadDay } from "@/lib/npm-stats";
 
 /**
  * Both charts plot a single measure — downloads — so they use one hue rather
@@ -22,13 +19,12 @@ import type { DownloadDay, VersionDownloads } from "@/lib/npm-stats";
 const SERIES_COLOR = "var(--stats-series)";
 
 /**
- * The chart primitives default to rounded marks — bars get an 8px cap and the
- * hover marker is a circle. This site's shadcn preset (`radix-sera`) is squared
- * everywhere, so the mark geometry is squared here, at the call site, using the
- * primitives' own props. The tooltip's own chrome has no such props and is
- * squared in `components/charts/tooltip` instead.
+ * The chart primitives default to a circular hover marker. This site's shadcn
+ * preset (`radix-sera`) is squared everywhere, so the mark geometry is squared
+ * here, at the call site, using the primitives' own props. The tooltip's own
+ * chrome has no such props and is squared in `components/charts/tooltip`
+ * instead.
  */
-const SQUARE_BAR_CAP = "butt" as const;
 const SQUARE_TOOLTIP_MARKER = {
   dotRadiusFraction: 0,
   dotVariant: "ring",
@@ -36,10 +32,6 @@ const SQUARE_TOOLTIP_MARKER = {
 
 interface DailyDownloadsChartProps {
   data: DownloadDay[];
-}
-
-interface VersionDownloadsChartProps {
-  data: VersionDownloads[];
 }
 
 const DAY_LABEL_FORMAT = new Intl.DateTimeFormat("en-US", {
@@ -72,25 +64,4 @@ function DailyDownloadsChart({ data }: DailyDownloadsChartProps) {
   );
 }
 
-function VersionDownloadsChart({ data }: VersionDownloadsChartProps) {
-  const points = data.map((entry) => ({
-    downloads: entry.downloads,
-    name: entry.version,
-  }));
-
-  return (
-    <BarChart
-      aspectRatio="3 / 1"
-      data={points}
-      margin={{ bottom: 32, left: 16, right: 16, top: 16 }}
-      xDataKey="name"
-    >
-      <Grid />
-      <BarXAxis />
-      <Bar dataKey="downloads" fill={SERIES_COLOR} lineCap={SQUARE_BAR_CAP} />
-      <ChartTooltip {...SQUARE_TOOLTIP_MARKER} />
-    </BarChart>
-  );
-}
-
-export { DailyDownloadsChart, formatDay, VersionDownloadsChart };
+export { DailyDownloadsChart, formatDay };

--- a/lib/npm-stats.ts
+++ b/lib/npm-stats.ts
@@ -10,18 +10,10 @@ const MAX_RANGE_DAYS = 540;
 const DAY_MS = 86_400_000;
 const ISO_DAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const PRERELEASE_PATTERN = /-/;
-/** Versions charted individually before the remainder is grouped. */
-const TOP_VERSION_COUNT = 6;
 
 interface DownloadDay {
   day: string;
   downloads: number;
-}
-
-interface VersionDownloads {
-  downloads: number;
-  isPrerelease: boolean;
-  version: string;
 }
 
 interface ReleaseMarker {
@@ -38,7 +30,6 @@ interface NpmStats {
   releases: ReleaseMarker[];
   totalDownloads: number;
   versionCount: number;
-  versions: VersionDownloads[];
 }
 
 type FetchImplementation = (
@@ -217,41 +208,6 @@ const parseDownloadRange = (payload: unknown): DownloadDay[] | null => {
   return days;
 };
 
-const parseVersionDownloads = (payload: unknown): VersionDownloads[] | null => {
-  if (typeof payload !== "object" || payload === null) {
-    return null;
-  }
-
-  const { downloads } = payload as Record<string, unknown>;
-
-  if (typeof downloads !== "object" || downloads === null) {
-    return null;
-  }
-
-  const versions: VersionDownloads[] = [];
-  for (const [version, count] of Object.entries(
-    downloads as Record<string, unknown>
-  )) {
-    if (!isDownloadCount(count)) {
-      return null;
-    }
-
-    if (count > 0) {
-      versions.push({
-        downloads: count,
-        isPrerelease: PRERELEASE_PATTERN.test(version),
-        version,
-      });
-    }
-  }
-
-  return versions.sort(
-    (left, right) =>
-      right.downloads - left.downloads ||
-      left.version.localeCompare(right.version)
-  );
-};
-
 const parseLastWeekDownloads = (payload: unknown): number | null => {
   if (typeof payload !== "object" || payload === null) {
     return null;
@@ -266,26 +222,6 @@ const parseLastWeekDownloads = (payload: unknown): number | null => {
  * Prereleases and the long tail are folded into one bar so the chart shows
  * which stable versions people actually run without a dozen slivers.
  */
-const summarizeVersions = (
-  versions: VersionDownloads[]
-): VersionDownloads[] => {
-  const stable = versions.filter((entry) => !entry.isPrerelease);
-  const rest = versions.filter((entry) => entry.isPrerelease);
-  const top = stable.slice(0, TOP_VERSION_COUNT);
-  const remainder = [...stable.slice(TOP_VERSION_COUNT), ...rest];
-  const remainderTotal = remainder.reduce(
-    (total, entry) => total + entry.downloads,
-    0
-  );
-
-  return remainderTotal > 0
-    ? [
-        ...top,
-        { downloads: remainderTotal, isPrerelease: false, version: "other" },
-      ]
-    : top;
-};
-
 const fetchNpmStats = async (
   now: number,
   fetchImplementation: FetchImplementation = fetch
@@ -304,13 +240,9 @@ const fetchNpmStats = async (
 
   const endDay = getLastCompleteDay(new Date(now));
   const startDay = clampRangeStart(registry.firstPublishedDay, endDay);
-  const [rangePayload, versionsPayload, lastWeekPayload] = await Promise.all([
+  const [rangePayload, lastWeekPayload] = await Promise.all([
     fetchJson(
       `${NPM_DOWNLOADS_ORIGIN}/downloads/range/${startDay}:${endDay}/${encodedName}`,
-      fetchImplementation
-    ),
-    fetchJson(
-      `${NPM_DOWNLOADS_ORIGIN}/versions/${encodedName}/last-week`,
       fetchImplementation
     ),
     fetchJson(
@@ -322,7 +254,6 @@ const fetchNpmStats = async (
   const daily = dropUnsettledTrailingDays(
     parseDownloadRange(rangePayload) ?? []
   );
-  const versions = parseVersionDownloads(versionsPayload) ?? [];
 
   return {
     daily,
@@ -332,7 +263,6 @@ const fetchNpmStats = async (
     releases: registry.releases.filter((release) => release.day >= startDay),
     totalDownloads: daily.reduce((total, entry) => total + entry.downloads, 0),
     versionCount: registry.versionCount,
-    versions: summarizeVersions(versions),
   };
 };
 
@@ -351,7 +281,7 @@ const getNpmStats = (): Promise<NpmStats | null> =>
       1000
   );
 
-export type { DownloadDay, NpmStats, ReleaseMarker, VersionDownloads };
+export type { DownloadDay, NpmStats, ReleaseMarker };
 export {
   clampRangeStart,
   encodePackageName,
@@ -361,6 +291,4 @@ export {
   PACKAGE_NAME,
   parseDownloadRange,
   parseRegistryMetadata,
-  parseVersionDownloads,
-  summarizeVersions,
 };

--- a/test/e2e/stats-page.spec.ts
+++ b/test/e2e/stats-page.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "@playwright/test";
 import { test } from "next/experimental/testmode/playwright.js";
 
+const RULESET_DETAIL_PATTERN = /^ruleset \d{4}\./;
 const UNAVAILABLE_PATTERN = /temporarily unavailable/i;
 
 const VIEWPORTS = [
@@ -58,7 +59,7 @@ const createNpmHandler =
     return "abort" as const;
   };
 
-test("shows npm usage with a per-version table", async ({ next, page }) => {
+test("shows npm usage and the bundled ruleset", async ({ next, page }) => {
   next.onFetch(createNpmHandler());
 
   await page.goto("/stats");
@@ -70,12 +71,16 @@ test("shows npm usage with a per-version table", async ({ next, page }) => {
     page.getByRole("heading", { level: 2, name: "Downloads per day" })
   ).toBeVisible();
 
-  // The version table is the non-visual reading of the bar chart, so it is
-  // what the test asserts on rather than the rendered SVG.
-  const table = page.getByRole("table");
-  await expect(table).toBeVisible();
-  await expect(table.getByRole("row")).toHaveCount(3);
-  await expect(table.getByRole("rowheader", { name: "0.7.0" })).toBeVisible();
+  // The tiles are the non-visual reading of the page, so they are what the
+  // test asserts on rather than the rendered SVG. A dt exposes no accessible
+  // name, so the tiles are matched by their text rather than by role name.
+  await expect(
+    page.getByRole("term").filter({ hasText: "Rules" })
+  ).toBeVisible();
+  await expect(page.getByText(RULESET_DETAIL_PATTERN)).toBeVisible();
+
+  // The per-version breakdown was removed; nothing should reintroduce a table.
+  await expect(page.getByRole("table")).toHaveCount(0);
 });
 
 test("degrades to a message when npm is unavailable", async ({

--- a/test/shadscan-web/npm-stats.test.ts
+++ b/test/shadscan-web/npm-stats.test.ts
@@ -5,10 +5,7 @@ import {
   fetchNpmStats,
   getLastCompleteDay,
   PACKAGE_NAME,
-  parseDownloadRange,
   parseRegistryMetadata,
-  parseVersionDownloads,
-  summarizeVersions,
 } from "../../lib/npm-stats";
 
 const REGISTRY_PAYLOAD = {
@@ -67,9 +64,6 @@ const createFetch = (
 const ALL_ROUTES = {
   "/downloads/point/last-week/": { downloads: 9631 },
   "/downloads/range/": RANGE_PAYLOAD,
-  "/versions/": {
-    downloads: { "0.1.0-rc.7": 72, "0.7.0": 3095, "0.8.0": 2302 },
-  },
   "registry.npmjs.org": REGISTRY_PAYLOAD,
 };
 
@@ -102,83 +96,6 @@ describe("npm stats helpers", () => {
       { day: "2026-07-27", version: "0.7.0" },
       { day: "2026-07-30", version: "0.8.0" },
     ]);
-  });
-
-  it("rejects payload shapes it does not recognize", () => {
-    expect(parseRegistryMetadata(null)).toBeNull();
-    expect(parseRegistryMetadata({ time: {} })).toBeNull();
-    expect(parseDownloadRange({ downloads: "nope" })).toBeNull();
-    expect(
-      parseDownloadRange({ downloads: [{ day: "x", downloads: 1 }] })
-    ).toBeNull();
-    expect(
-      parseDownloadRange({ downloads: [{ day: "2026-07-27", downloads: -1 }] })
-    ).toBeNull();
-    expect(
-      parseVersionDownloads({ downloads: { "1.0.0": "many" } })
-    ).toBeNull();
-  });
-
-  it("orders versions by downloads and flags prereleases", () => {
-    const versions = parseVersionDownloads({
-      downloads: { "0.1.0-rc.7": 72, "0.7.0": 3095, "0.8.0": 2302 },
-    });
-
-    expect(versions?.map((entry) => entry.version)).toEqual([
-      "0.7.0",
-      "0.8.0",
-      "0.1.0-rc.7",
-    ]);
-    expect(versions?.at(-1)?.isPrerelease).toBe(true);
-  });
-
-  it("groups prereleases and the long tail into one other bar", () => {
-    const summarized = summarizeVersions([
-      { downloads: 100, isPrerelease: false, version: "0.8.0" },
-      { downloads: 90, isPrerelease: false, version: "0.7.0" },
-      { downloads: 80, isPrerelease: false, version: "0.6.1" },
-      { downloads: 70, isPrerelease: false, version: "0.6.0" },
-      { downloads: 60, isPrerelease: false, version: "0.5.0" },
-      { downloads: 50, isPrerelease: false, version: "0.4.0" },
-      { downloads: 40, isPrerelease: false, version: "0.3.0" },
-      { downloads: 5, isPrerelease: true, version: "0.1.0-rc.7" },
-    ]);
-
-    expect(summarized).toHaveLength(7);
-    expect(summarized.at(-1)).toEqual({
-      downloads: 45,
-      isPrerelease: false,
-      version: "other",
-    });
-  });
-
-  it("omits the other bar when nothing is left over", () => {
-    const summarized = summarizeVersions([
-      { downloads: 100, isPrerelease: false, version: "0.8.0" },
-    ]);
-
-    expect(summarized).toEqual([
-      { downloads: 100, isPrerelease: false, version: "0.8.0" },
-    ]);
-  });
-});
-
-describe("fetchNpmStats", () => {
-  it("assembles stats from every endpoint", async () => {
-    const { calls, fetchImplementation } = createFetch(ALL_ROUTES);
-    const stats = await fetchNpmStats(NOW, fetchImplementation);
-
-    expect(stats?.firstPublishedDay).toBe("2026-07-22");
-    expect(stats?.latestVersion).toBe("0.8.0");
-    expect(stats?.lastWeekDownloads).toBe(9631);
-    expect(stats?.totalDownloads).toBe(4609);
-    expect(stats?.daily).toHaveLength(3);
-    expect(stats?.versions.map((entry) => entry.version)).toEqual([
-      "0.7.0",
-      "0.8.0",
-      "other",
-    ]);
-    expect(calls.some((url) => url.includes("@shadscan%2Fcli"))).toBe(true);
   });
 
   it("drops trailing days npm has not settled yet", async () => {
@@ -258,15 +175,13 @@ describe("fetchNpmStats", () => {
   it("degrades to partial stats when only the downloads API fails", async () => {
     const { fetchImplementation } = createFetch(ALL_ROUTES, {
       "/downloads/": 503,
-      "/versions/": 503,
     });
     const stats = await fetchNpmStats(NOW, fetchImplementation);
 
-    // The registry answered, so the page still gets versions and release
-    // markers rather than an error boundary.
+    // The registry answered, so the page still gets the version count and
+    // release markers rather than an error boundary.
     expect(stats).not.toBeNull();
     expect(stats?.daily).toEqual([]);
-    expect(stats?.versions).toEqual([]);
     expect(stats?.totalDownloads).toBe(0);
     expect(stats?.lastWeekDownloads).toBeNull();
     expect(stats?.latestVersion).toBe("0.8.0");

--- a/test/shadscan-web/stats-social-copy.test.ts
+++ b/test/shadscan-web/stats-social-copy.test.ts
@@ -10,7 +10,6 @@ const createStats = (overrides: Partial<NpmStats> = {}): NpmStats => ({
   releases: [],
   totalDownloads: 45_231,
   versionCount: 12,
-  versions: [],
   ...overrides,
 });
 


### PR DESCRIPTION
Removes the **"Which versions people run"** section from `/stats` — the bar chart and the table beneath it.

It was the weakest thing on the page. npm publishes no per-version history, so it could only ever be a 7-day snapshot that never becomes a trend, and the `Versions` tile already reports how many versions exist.

## The dead data path goes with it

Removing the section left its entire supporting path unreachable, so that is removed rather than left behind:

- `VersionDownloadsChart` (its only consumer was this section)
- the `VersionDownloads` type, `parseVersionDownloads`, `summarizeVersions`
- `TOP_VERSION_COUNT`, which existed only for `summarizeVersions`
- `SQUARE_BAR_CAP`, which only squared the bar chart's caps
- the `Bar` / `BarChart` / `BarXAxis` imports

`PRERELEASE_PATTERN` **stays** — it still filters release markers, and deleting it would have been the easy mistake here.

**The page now makes three npm requests per revalidate instead of four**, since nothing reads the per-version endpoint any more.

## The test that was quietly wrong

The e2e spec asserted on the removed table (`toHaveCount(3)` rows, a `0.7.0` rowheader). It now asserts on the tiles, plus `expect(page.getByRole("table")).toHaveCount(0)` so nothing reintroduces a table by accident.

Getting that assertion right took three attempts, worth recording: `getByText("Rules")` was ambiguous, and `getByRole("term", { name: "Rules" })` finds nothing because a `<dt>` exposes no accessible name from its text. `getByRole("term").filter({ hasText: "Rules" })` is the correct form. I read Playwright's own page snapshot to establish that rather than guessing again.

## Verification

8 gates green, including e2e across all three viewports. Self-audit 100/100 A.

Site-only — no rule logic, no ruleset bump, no schema change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified the stats page to focus on daily download activity.
  * Removed version adoption charts, explanatory content, and per-version download tables.
  * Updated stats behavior to display daily and recent download totals only.
* **Bug Fixes**
  * Improved handling and verification of partial download-statistics failures.
* **Tests**
  * Updated end-to-end coverage to validate ruleset details and confirm that no version table appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->