### PR TITLE
feat(cli): add rendered horizontal overflow check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,7 +100,10 @@ jobs:
           echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
           echo "sha512=$digest" >> "$GITHUB_OUTPUT"
       - name: Smoke test exact npm artifact
-        run: node packages/cli/scripts/smoke-package.mjs --tarball "${{ steps.pack.outputs.tarball }}"
+        shell: bash
+        run: |
+          browser_executable="$(node --input-type=module -e 'import { chromium } from "@playwright/test"; process.stdout.write(chromium.executablePath())')"
+          node packages/cli/scripts/smoke-package.mjs --tarball "${{ steps.pack.outputs.tarball }}" --browser-executable "$browser_executable"
       - name: Stage package for npm approval
         shell: bash
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -94,9 +94,12 @@ jobs:
       - name: Install Chromium for packed overflow smoke
         if: matrix.os == 'ubuntu-latest' && matrix.node == 18
         shell: bash
-        run: |
-          pnpm --filter @shadscan/cli exec playwright-core install --with-deps chromium
-          browser_executable="$(pnpm --filter @shadscan/cli exec node --input-type=module -e 'import { chromium } from "playwright-core"; process.stdout.write(chromium.executablePath())')"
-          echo "SHADSCAN_SMOKE_BROWSER_EXECUTABLE=$browser_executable" >> "$GITHUB_ENV"
+        run: pnpm --filter @shadscan/cli exec playwright-core install --with-deps chromium
       - name: Smoke test packed CLI
         run: pnpm cli:smoke:built
+      - name: Smoke test packed overflow mode
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 18
+        shell: bash
+        run: |
+          browser_executable="$(node --input-type=module -e 'import { createRequire } from "node:module"; const require = createRequire(new URL("./packages/cli/package.json", import.meta.url)); const { chromium } = require("playwright-core"); process.stdout.write(chromium.executablePath())')"
+          node packages/cli/scripts/smoke-package.mjs --browser-executable "$browser_executable"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -91,5 +91,12 @@ jobs:
         run: pnpm install --frozen-lockfile --filter @shadscan/cli...
       - name: Build CLI
         run: pnpm cli:build
+      - name: Install Chromium for packed overflow smoke
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 18
+        shell: bash
+        run: |
+          pnpm --filter @shadscan/cli exec playwright-core install --with-deps chromium
+          browser_executable="$(pnpm --filter @shadscan/cli exec node --input-type=module -e 'import { chromium } from "playwright-core"; process.stdout.write(chromium.executablePath())')"
+          echo "SHADSCAN_SMOKE_BROWSER_EXECUTABLE=$browser_executable" >> "$GITHUB_ENV"
       - name: Smoke test packed CLI
         run: pnpm cli:smoke:built

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ stable releases published under `latest`.
 
 ## Unreleased
 
+### Added
+
+- A standalone `--check-overflow <url>` CLI mode that opens an already-running
+  local or deployed app in isolated Chromium contexts and treats any
+  document-level horizontal overflow or forced root scrollbar as a critical
+  failure at fixed mobile (320 × 820) and desktop (1440 × 1000) viewports.
+  Repeatable `--route` options cover up to ten same-origin pages, human and
+  versioned JSON reports include bounded likely-culprit evidence, and
+  operational failures stay separate from product failures. This rendered
+  check does not add a catalog rule, score, or grade and leaves the static
+  source audit unchanged.
+
 ## 0.13.0 - 2026-08-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -121,12 +121,62 @@ pnpm dlx @shadscan/cli --list-projects
 
 # Scan one package of a monorepo instead of pooling every application
 pnpm dlx @shadscan/cli --project apps/web
+
+# Check a running app for horizontal overflow at mobile and desktop widths
+pnpm dlx @shadscan/cli --check-overflow http://localhost:3000
+
+# Include more same-origin routes (the target URL is always checked)
+pnpm dlx @shadscan/cli --check-overflow http://localhost:3000 --route /dashboard --route /settings
 ```
 
 Use `--format human`, `--format json`, or `--format prompt` when output selection
 needs to be explicit. Pin an exact package version in CI; unqualified commands
 resolve to the latest stable release. Run `pnpm dlx @shadscan/cli --help` for
 every option.
+
+## Check Rendered Horizontal Overflow
+
+The focused `--check-overflow` command opens an already-running local or
+deployed app in isolated Chromium pages and checks these fixed CSS viewports:
+
+- mobile: 320 × 820;
+- desktop: 1440 × 1000.
+
+It reports a critical failure if the document has even one CSS pixel of
+horizontal overflow, or if the root or body forces a horizontal scrollbar.
+Likely culprit selectors are included when Shadscan can identify them. The
+target URL is always checked; repeat `--route` to add up to ten
+same-origin paths beginning with `/`. Routes cannot contain a query string or
+fragment.
+
+This command is separate from the default static source audit. It does not add
+a rule, score, or grade, and it leaves the 62-rule catalog and existing
+`mobile-overflow-absent` advisory unchanged. Shadscan does not start or build
+the target app, so start it yourself first or pass a deployed URL. The command
+can run outside a project directory.
+
+```bash
+# Human report
+pnpm dlx @shadscan/cli --check-overflow http://localhost:3000
+
+# Versioned JSON for automation
+pnpm dlx @shadscan/cli --check-overflow https://preview.example.com --json
+```
+
+A clean result exits `0`. Detected overflow exits `1` after writing the
+complete human or JSON report to stdout. Browser, target, timeout, and argument
+errors exit `1`, leave stdout empty, and write the error to stderr. If no
+supported Chromium installation is available, run:
+
+```bash
+pnpm dlx playwright-core@1.61.1 install chromium
+```
+
+The overflow check performs GET navigations and executes the target's page
+JavaScript in fresh isolated browser contexts. It reads no project source,
+invokes no package scripts, and saves no page data. This focused mode is
+available only in the local CLI in its first release, not through MCP, the
+GitHub Action, hosted API, or web scanner.
 
 ## GitHub Action
 

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -44,6 +44,20 @@ const CLI_OPTIONS = [
   },
   {
     description:
+      "Check an already-running HTTP or HTTPS app for document-level horizontal overflow at fixed mobile and desktop viewports.",
+    option: "--check-overflow <url>",
+  },
+  {
+    description:
+      "Add a same-origin path beginning with /. Query strings and fragments are not accepted. Repeatable; ten total pages maximum.",
+    option: "--route <path>",
+  },
+  {
+    description: "Use a specific Chromium-family executable for overflow mode.",
+    option: "--browser-executable <path>",
+  },
+  {
+    description:
       "Choose human, json, or prompt output. Human output is the default.",
     option: "--format <format>",
   },
@@ -143,8 +157,8 @@ function DocsCodeBlock({ code, label, language }: DocsCodeBlockProps) {
 
 export const metadata = createPageMetadata({
   description:
-    "Run Shadscan, inspect a progress-bar score, launch a coding agent, enforce score thresholds, and add a safe pre-commit gate.",
-  imageAlt: "Shadscan CLI scoring, agent launch, and pre-commit setup",
+    "Run Shadscan, check rendered horizontal overflow, inspect a progress-bar score, launch a coding agent, and enforce score thresholds.",
+  imageAlt: "Shadscan CLI source audits and rendered overflow checks",
   imagePath: "/docs/opengraph-image",
   path: "/docs",
   title: "Shadscan CLI documentation",
@@ -185,7 +199,9 @@ export default function DocsPage() {
         <section id="usage">
           <h2>Usage</h2>
           <DocsCodeBlock
-            code="shadscan [path] [options]"
+            code={
+              "shadscan [path] [options]\nshadscan --check-overflow <url> [--route <path> ...]"
+            }
             label="Syntax"
             language="bash"
           />
@@ -262,6 +278,72 @@ export default function DocsPage() {
           </p>
         </section>
 
+        <section id="overflow-check">
+          <h2>Check rendered horizontal overflow</h2>
+          <div className="not-typeset mt-4">
+            <CodeBlockCommand
+              {...getCliCommands(
+                "--check-overflow http://localhost:3000 --route /dashboard"
+              )}
+            />
+          </div>
+          <p>
+            Start your app first, or pass a deployed URL. Shadscan does not
+            install dependencies, build the app, or run its dev or start
+            scripts. This mode checks the supplied URL from any directory, so it
+            does not need a project or <code>package.json</code>. The target URL
+            is always included; repeat <code>--route</code> to check more
+            same-origin paths beginning with <code>/</code>, up to ten pages in
+            total. Routes cannot contain query strings or fragments.
+          </p>
+          <p>The two fixed CSS viewports are:</p>
+          <ul>
+            <li>Mobile: 320 × 820.</li>
+            <li>Desktop: 1440 × 1000.</li>
+          </ul>
+          <p>
+            Any document-level horizontal overflow is a critical failure,
+            including a single CSS pixel or a horizontal scrollbar forced on the
+            root or body. Failed measurements include bounded likely culprit
+            selectors when Shadscan can identify them. Local scroll areas that
+            do not enlarge the document remain valid.
+          </p>
+          <p>
+            This is a standalone rendered check, not another source-audit rule.
+            It produces no score or grade and does not change the 62-rule
+            catalog, ruleset, audit schema, or existing{" "}
+            <code>mobile-overflow-absent</code> advisory.
+          </p>
+          <h3>Use it in automation</h3>
+          <div className="not-typeset mt-4">
+            <CodeBlockCommand
+              {...getCliCommands(
+                "--check-overflow https://preview.example.com --json"
+              )}
+            />
+          </div>
+          <p>
+            A clean result exits <code>0</code>. Detected overflow exits{" "}
+            <code>1</code> after writing the complete human or versioned JSON
+            report to stdout. Browser, target, timeout, response, stability, and
+            argument errors also exit <code>1</code>, but leave stdout empty and
+            write the error to stderr.
+          </p>
+          <h3>Install Chromium if needed</h3>
+          <DocsCodeBlock
+            code="pnpm dlx playwright-core@1.61.1 install chromium"
+            label="Browser install"
+            language="bash"
+          />
+          <p>
+            Overflow mode performs GET navigations and executes the target
+            page&apos;s JavaScript in fresh isolated Chromium contexts. It reads
+            no project source, invokes no package scripts, and saves no page
+            data. In its first release it is available only in the local CLI,
+            not through MCP, the GitHub Action, hosted API, or web scanner.
+          </p>
+        </section>
+
         <section id="options">
           <h2>Options</h2>
           <dl className="not-typeset mt-5 border-y">
@@ -287,7 +369,10 @@ export default function DocsPage() {
             and <code>production-polish</code>. The <code>--prompt</code> and{" "}
             <code>--json</code> aliases cannot be combined with each other or
             with <code>--format</code>. <code>--apply</code> requires human
-            output, and <code>--agent</code> requires <code>--apply</code>.
+            output, and <code>--agent</code> requires <code>--apply</code>. In
+            overflow mode, only human or JSON output is available; source-audit
+            paths, score, category, prompt, agent, project-selection, and roast
+            options are rejected.
           </p>
         </section>
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -8,6 +8,7 @@ a local install, a packed tarball, or npm through `npx`.
 ```text
 shadscan [path] [options]
 shadscan setup [path] --pre-commit [--dry-run | --yes]
+shadscan --check-overflow <url> [--route <path> ...]
 ```
 
 - `path` selects the React project to scan and defaults to the current working
@@ -24,6 +25,25 @@ shadscan setup [path] --pre-commit [--dry-run | --yes]
 - `setup --pre-commit` plans a version-pinned score gate from the current
   complete assessed score. `--dry-run` never writes; `--yes` confirms an
   automatic safe plan without a prompt.
+- `--check-overflow <url>` is a standalone rendered check. It requires an
+  absolute HTTP or HTTPS URL for an already-running local or deployed app and
+  does not resolve or discover a project. The supplied URL is always checked;
+  repeatable `--route <path>` values add same-origin paths that begin with
+  exactly one `/`, up to ten pages in total. Routes cannot contain a query
+  string, fragment, or backslash.
+- The overflow check uses fixed CSS viewports of 320 × 820 (mobile) and 1440 ×
+  1000 (desktop), both at device scale factor 1. It fails on any
+  document-level horizontal overflow or a horizontal scrollbar forced on the
+  root or body. It does not add an audit rule, score, or grade and does not
+  change the source audit, bundled rule count, ruleset, or audit schema.
+- The caller starts or deploys the target app. Shadscan does not run install,
+  dev, build, or start scripts for overflow mode. `--browser-executable <path>`
+  may select a Chromium-family executable explicitly.
+- Overflow mode accepts human or JSON output, `--route`,
+  `--browser-executable`, `--no-interactive`, and `--no-roast`. It rejects a
+  non-default project path and source-audit-only score, category, prompt, agent,
+  project-selection, listing, and positive-roast options. `--route` and
+  `--browser-executable` are invalid without `--check-overflow`.
 
 ## Output
 
@@ -34,6 +54,14 @@ shadscan setup [path] --pre-commit [--dry-run | --yes]
 - `--format json` and `--json` write one versioned JSON report to stdout.
 - `--format prompt` and `--prompt` write one deterministic agent handoff to
   stdout.
+- Overflow mode supports human output, `--format human`, `--format json`, and
+  `--json`. Its JSON output is a separate versioned `overflow-check` report,
+  not an audit report. It contains every requested page and viewport
+  measurement, bounded likely-culprit selectors for failures, and a summary,
+  but no score, grade, or rule result.
+- A detected overflow writes the complete human or JSON report to stdout before
+  exiting non-zero. An overflow operational failure leaves stdout empty and
+  writes a stable human or versioned JSON error to stderr.
 - Expected CLI failures write a stable message to stderr. JSON-selected
   failures write a versioned JSON error object to stderr.
 - Interactive scan progress, menus, warnings, confirmations, and launched-agent
@@ -63,6 +91,10 @@ shadscan setup [path] --pre-commit [--dry-run | --yes]
   `--fail-under` was not satisfied.
 - Findings do not fail the process unless the caller supplies `--fail-under`.
 - Launching an agent never clears an existing score-threshold failure.
+- In overflow mode, `0` means every requested page fit both fixed viewports.
+  Detected overflow is a critical failure and exits `1`. Invalid arguments,
+  an unavailable browser or target, unsupported response, unstable page,
+  timeout, redirect-policy violation, and measurement failure also exit `1`.
 
 ## Stability
 
@@ -77,6 +109,12 @@ shadscan setup [path] --pre-commit [--dry-run | --yes]
 - The scanner itself does not send project source, findings, or environment
   variables over the network. An explicitly launched external agent may read
   and edit files, run commands, and send the generated prompt to its provider.
+- Overflow mode is an explicit network exception: it performs GET navigations
+  to the supplied target and same-origin routes, follows only same-origin
+  redirects, and executes the target's page JavaScript in fresh isolated
+  Chromium contexts. It reads no project source, invokes no package
+  scripts, persists no cookies between measurements, and saves no page data.
+  Query strings and fragments are redacted from reports.
 - Agent discovery only trusts executables outside the project, validates their
   provider-specific `--version` output, passes argument arrays without building
   a user-controlled shell command, adds no approval-bypass flags, and
@@ -98,3 +136,5 @@ shadscan setup [path] --pre-commit [--dry-run | --yes]
   is `prepack`, which builds the distributable before packaging.
 - The hosted API is a separate opt-in surface with its own authentication and
   source-handling contract.
+- Overflow mode is local-CLI-only in its first release. It is not exposed by
+  MCP, the GitHub Action, hosted API, or web scanner.

--- a/lib/docs-sections.ts
+++ b/lib/docs-sections.ts
@@ -2,6 +2,7 @@ import type { DocsSection } from "@/components/docs-on-this-page";
 
 const DOCS_SECTIONS = [
   { href: "#usage", label: "Usage" },
+  { href: "#overflow-check", label: "Overflow check" },
   { href: "#options", label: "Options" },
   { href: "#agent-prompt", label: "Agent prompt" },
   { href: "#apply", label: "Apply with an agent" },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -113,6 +113,12 @@ pnpm exec shadscan --fail-under 80 --no-interactive --no-roast
 
 # Audit one category while investigating a focused area
 pnpm dlx @shadscan/cli --category accessibility
+
+# Check an already-running app for horizontal overflow
+pnpm dlx @shadscan/cli --check-overflow http://localhost:3000
+
+# Add same-origin routes to the target URL
+pnpm dlx @shadscan/cli --check-overflow http://localhost:3000 --route /dashboard --route /settings
 ```
 
 Use `--format human`, `--format json`, or `--format prompt` when output selection
@@ -120,6 +126,36 @@ needs to be explicit.
 
 Pin an exact package version in CI; unqualified commands resolve to the latest
 stable release. Run `pnpm dlx @shadscan/cli --help` for every option.
+
+## Rendered Horizontal Overflow
+
+`--check-overflow <url>` is a focused critical gate for an already-running
+local or deployed app. It opens isolated Chromium pages at two fixed CSS
+viewports — mobile at 320 × 820 and desktop at 1440 × 1000 — and fails on any
+document-level horizontal overflow, including a one-pixel overflow or a
+horizontal scrollbar forced on the root or body. The target URL is always
+checked; repeat `--route <path>` to add same-origin pages, up to ten pages in
+total. Each route must begin with `/` and cannot contain a query string or
+fragment.
+
+This is separate from the default static source audit. It does not add a rule,
+score, or grade, and the 62-rule catalog and existing
+`mobile-overflow-absent` advisory stay unchanged. Shadscan does not start or
+build the target app, and the command does not need a project directory.
+
+Use `--json` for its versioned standalone report. A clean result exits `0`.
+Detected overflow exits `1` with the complete report on stdout. Operational or
+argument errors exit `1`, keep stdout empty, and write the error to stderr. If
+Chromium is not available, install the matching managed browser with:
+
+```bash
+pnpm dlx playwright-core@1.61.1 install chromium
+```
+
+The overflow check performs GET navigations and executes page JavaScript in
+fresh isolated browser contexts. It reads no project source, invokes no package
+scripts, and saves no page data. In its first release it is available only in
+the local CLI, not through MCP, the GitHub Action, hosted API, or web scanner.
 
 ## Agent Handoff
 
@@ -208,7 +244,9 @@ generic React applications.
 
 ## Privacy And Exit Status
 
-Local scanning is static and stays on your machine.
+The default local scan is static and stays on your machine. The explicit
+`--check-overflow` mode navigates to the URL you provide under the separate
+rendered-check contract above.
 
 Findings return exit status `0` unless `--fail-under` is not satisfied.
 Discovery, audit, setup, and launched-agent failures return `1`. Use

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,6 +64,7 @@
     "cross-spawn": "7.0.6",
     "jsonc-parser": "3.3.1",
     "picocolors": "1.1.1",
+    "playwright-core": "1.61.1",
     "tinyglobby": "0.2.15",
     "typescript": "5.9.3",
     "zod": "4.1.13"

--- a/packages/cli/scripts/smoke-package.mjs
+++ b/packages/cli/scripts/smoke-package.mjs
@@ -8,6 +8,7 @@ import {
   rm,
   writeFile,
 } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,6 +26,7 @@ const temporaryRoot = await mkdtemp(
   path.join(tmpdir(), "shadscan packed smoke ")
 );
 const npmCacheDirectory = path.join(temporaryRoot, "npm cache");
+let overflowFixtureServer;
 
 const getOptionValue = (optionName) => {
   const optionIndex = process.argv.indexOf(optionName);
@@ -62,6 +64,55 @@ const run = async (command, args, { cwd, expectedExitCode = 0 } = {}) => {
   );
 
   return result;
+};
+
+const startOverflowFixture = async () => {
+  overflowFixtureServer = createServer((request, response) => {
+    const requestUrl = new URL(
+      request.url ?? "/",
+      `http://${request.headers.host ?? "127.0.0.1"}`
+    );
+    const isOverflow = requestUrl.pathname === "/overflow";
+    const markup = isOverflow
+      ? '<div data-slot="packed-overflow" style="height:1px;width:calc(100vw + 1px)"></div>'
+      : "<main>Packed artifact fits</main>";
+
+    response.writeHead(200, {
+      "cache-control": "no-store",
+      "content-type": "text/html; charset=utf-8",
+    });
+    response.end(
+      `<!doctype html><html><head><style>html,body{margin:0;padding:0}</style><title>Packed overflow fixture</title></head><body>${markup}</body></html>`
+    );
+  });
+
+  await new Promise((resolveListen, rejectListen) => {
+    overflowFixtureServer.once("error", rejectListen);
+    overflowFixtureServer.listen(0, "127.0.0.1", resolveListen);
+  });
+
+  const address = overflowFixtureServer.address();
+  assert.ok(
+    address && typeof address !== "string",
+    "Expected the packed overflow fixture to bind to a TCP port."
+  );
+  return `http://127.0.0.1:${address.port}`;
+};
+
+const stopOverflowFixture = async () => {
+  if (!overflowFixtureServer?.listening) {
+    return;
+  }
+
+  await new Promise((resolveClose, rejectClose) => {
+    overflowFixtureServer.close((error) => {
+      if (error) {
+        rejectClose(error);
+        return;
+      }
+      resolveClose();
+    });
+  });
 };
 
 try {
@@ -148,6 +199,7 @@ try {
   });
   assert.match(helpResult.stdout, /--apply/);
   assert.match(helpResult.stdout, /--agent <agent>/);
+  assert.match(helpResult.stdout, /--check-overflow <url>/);
   assert.match(helpResult.stdout, /--no-interactive/);
   assert.match(helpResult.stdout, /setup/);
 
@@ -233,6 +285,75 @@ try {
     expectedExitCode: 1,
   });
   assert.match(invalidAgentResult.stderr, /--agent requires --apply/);
+
+  const invalidOverflowResult = await run(
+    executable,
+    ["--check-overflow", "not-a-url", "--json"],
+    {
+      cwd: consumerDirectory,
+      expectedExitCode: 1,
+    }
+  );
+  assert.equal(invalidOverflowResult.stdout, "");
+  assert.equal(
+    JSON.parse(invalidOverflowResult.stderr).error.code,
+    "INVALID_ARGUMENTS"
+  );
+
+  const browserExecutable =
+    getOptionValue("--browser-executable") ??
+    process.env.SHADSCAN_SMOKE_BROWSER_EXECUTABLE;
+  if (browserExecutable) {
+    await access(browserExecutable);
+    const overflowFixtureOrigin = await startOverflowFixture();
+    const browserArguments = [
+      "--browser-executable",
+      browserExecutable,
+      "--json",
+      "--no-interactive",
+    ];
+    const fittingOverflowResult = await run(
+      executable,
+      [
+        "--check-overflow",
+        `${overflowFixtureOrigin}/fits`,
+        ...browserArguments,
+      ],
+      { cwd: consumerDirectory }
+    );
+    assert.equal(fittingOverflowResult.stderr, "");
+    assert.deepEqual(
+      {
+        status: JSON.parse(fittingOverflowResult.stdout).status,
+        summary: JSON.parse(fittingOverflowResult.stdout).summary,
+      },
+      {
+        status: "pass",
+        summary: { failed: 0, maximumOverflowPx: 0, measurements: 2 },
+      }
+    );
+
+    const failingOverflowResult = await run(
+      executable,
+      [
+        "--check-overflow",
+        `${overflowFixtureOrigin}/overflow`,
+        ...browserArguments,
+      ],
+      { cwd: consumerDirectory, expectedExitCode: 1 }
+    );
+    assert.equal(failingOverflowResult.stderr, "");
+    assert.deepEqual(
+      {
+        status: JSON.parse(failingOverflowResult.stdout).status,
+        summary: JSON.parse(failingOverflowResult.stdout).summary,
+      },
+      {
+        status: "fail",
+        summary: { failed: 2, maximumOverflowPx: 1, measurements: 2 },
+      }
+    );
+  }
 
   const setupPreviewResult = await run(
     executable,
@@ -352,9 +473,14 @@ try {
   assert.ok(Number.isInteger(scanPayload.score));
   assert.ok(Array.isArray(scanPayload.actionables));
 
+  const overflowSummary = browserExecutable ? ", browser overflow" : "";
   process.stdout.write(
-    `Packed shadscan ${packageManifest.version} passed npx, install, bin, output, threshold, import, MCP bundle-audit, and MCP stdio smoke tests.\n`
+    `Packed shadscan ${packageManifest.version} passed npx, install, bin, output, threshold, import${overflowSummary}, MCP bundle-audit, and MCP stdio smoke tests.\n`
   );
 } finally {
-  await rm(temporaryRoot, { force: true, recursive: true });
+  try {
+    await stopOverflowFixture();
+  } finally {
+    await rm(temporaryRoot, { force: true, recursive: true });
+  }
 }

--- a/packages/cli/src/cli-error.ts
+++ b/packages/cli/src/cli-error.ts
@@ -4,6 +4,10 @@ import {
   ProjectDiscoveryError,
   type ProjectDiscoveryErrorCode,
 } from "./discovery";
+import {
+  OverflowCheckError,
+  type OverflowCheckErrorCode,
+} from "./overflow-check/error";
 import { PreCommitError, type PreCommitErrorCode } from "./pre-commit";
 
 const COMMANDER_ERROR_PREFIX_PATTERN = /^error:\s*/i;
@@ -14,12 +18,20 @@ interface CliFailure {
     | "INVALID_ARGUMENTS"
     | "INVALID_PROJECT_METADATA"
     | AgentCliErrorCode
+    | OverflowCheckErrorCode
     | PreCommitErrorCode
     | ProjectDiscoveryErrorCode;
   message: string;
 }
 
 const normalizeCliFailure = (error: unknown): CliFailure => {
+  if (error instanceof OverflowCheckError) {
+    return {
+      code: error.code,
+      message: error.message,
+    };
+  }
+
   if (error instanceof AgentCliError || error instanceof PreCommitError) {
     return {
       code: error.code,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -30,6 +30,13 @@ import {
   resolveOutputFormat,
   wantsJsonOutput,
 } from "./output-format";
+import type {
+  OverflowBrowserCheckResult,
+  RunOverflowBrowserCheckOptions,
+} from "./overflow-check/browser";
+import { evaluateOverflowCheck } from "./overflow-check/evaluate";
+import { resolveOverflowCheckTarget } from "./overflow-check/options";
+import { renderOverflowCheckReport } from "./overflow-check/render-human";
 import {
   promptPostScanAction,
   resolveInteractiveMode,
@@ -59,7 +66,9 @@ const VERSION = packageJson.version;
 interface CliOptions {
   agent?: AgentId;
   apply?: boolean;
+  browserExecutable?: string;
   category?: AuditCategory;
+  checkOverflow?: string;
   failUnder?: number;
   format?: OutputFormat;
   interactive: boolean;
@@ -68,12 +77,21 @@ interface CliOptions {
   project?: string;
   prompt?: boolean;
   roast?: boolean;
+  route?: string[];
 }
 
 interface SetupOptions {
   dryRun?: boolean;
   preCommit: boolean;
   yes?: boolean;
+}
+
+type OverflowBrowserRunner = (
+  options: RunOverflowBrowserCheckOptions
+) => Promise<OverflowBrowserCheckResult>;
+
+interface OverflowCheckRuntime {
+  runBrowserCheck?: OverflowBrowserRunner;
 }
 
 const parseScore = (value: string): number => {
@@ -106,6 +124,11 @@ const parseAgent = (value: string): AgentId => {
   } catch {
     throw new InvalidArgumentError("Expected one of: claude, codex, grok.");
   }
+};
+
+const collectRoute = (value: string, routes: string[] = []): string[] => {
+  routes.push(value);
+  return routes;
 };
 
 const scoreFailsThreshold = (
@@ -473,6 +496,144 @@ const validateScanActionOptions = (
   }
 };
 
+const validateOverflowModeOptions = ({
+  command,
+  options,
+  outputFormat,
+  projectPath,
+}: {
+  command: Command;
+  options: CliOptions;
+  outputFormat: OutputFormat;
+  projectPath: string;
+}): void => {
+  if (projectPath !== ".") {
+    throw new InvalidArgumentError(
+      "--check-overflow does not accept a project path."
+    );
+  }
+
+  const incompatibleOption = [
+    options.category === undefined ? null : "--category",
+    options.failUnder === undefined ? null : "--fail-under",
+    options.apply ? "--apply" : null,
+    options.agent ? "--agent" : null,
+    options.prompt || outputFormat === "prompt" ? "--prompt" : null,
+    options.listProjects ? "--list-projects" : null,
+    options.project ? "--project" : null,
+    command.getOptionValueSource("roast") === "cli" && options.roast === true
+      ? "--roast"
+      : null,
+  ].find((option): option is string => option !== null);
+
+  if (incompatibleOption) {
+    throw new InvalidArgumentError(
+      `--check-overflow cannot be used with ${incompatibleOption}.`
+    );
+  }
+};
+
+const validateFocusedOptions = (options: CliOptions): void => {
+  if (options.checkOverflow !== undefined) {
+    return;
+  }
+
+  if ((options.route?.length ?? 0) > 0) {
+    throw new InvalidArgumentError("--route requires --check-overflow.");
+  }
+
+  if (options.browserExecutable !== undefined) {
+    throw new InvalidArgumentError(
+      "--browser-executable requires --check-overflow."
+    );
+  }
+};
+
+const rejectFocusedOptionsForSubcommand = (command: Command): void => {
+  const rootOptions = command.parent?.opts<CliOptions>();
+  if (
+    rootOptions?.checkOverflow !== undefined ||
+    rootOptions?.browserExecutable !== undefined ||
+    (rootOptions?.route?.length ?? 0) > 0
+  ) {
+    throw new InvalidArgumentError(
+      "--check-overflow and its related options cannot be used with subcommands."
+    );
+  }
+};
+
+const getOutputTerminalCapabilities = () =>
+  resolveTerminalCapabilities({
+    columns: process.stdout.columns,
+    env: {
+      CI: process.env.CI,
+      FORCE_COLOR: process.env.FORCE_COLOR,
+      NO_COLOR: process.env.NO_COLOR,
+      TERM: process.env.TERM,
+    },
+    isTTY: process.stdout.isTTY === true,
+  });
+
+const runOverflowCheckAction = async (
+  {
+    browserExecutable,
+    outputFormat,
+    routes,
+    target,
+  }: {
+    browserExecutable?: string;
+    outputFormat: OutputFormat;
+    routes?: string[];
+    target: string;
+  },
+  runtime: OverflowCheckRuntime = {}
+): Promise<void> => {
+  const resolvedTarget = resolveOverflowCheckTarget({ routes, target });
+  let runBrowserCheck = runtime.runBrowserCheck;
+
+  if (!runBrowserCheck) {
+    ({ runOverflowBrowserCheck: runBrowserCheck } = await import(
+      "./overflow-check/browser"
+    ));
+  }
+
+  const abortController = new AbortController();
+  const abortCheck = (): void => abortController.abort();
+  process.once("SIGINT", abortCheck);
+  process.once("SIGTERM", abortCheck);
+
+  try {
+    const browserResult = await runBrowserCheck({
+      browserExecutable,
+      origin: resolvedTarget.origin,
+      pages: resolvedTarget.pages,
+      signal: abortController.signal,
+    });
+    const report = evaluateOverflowCheck({
+      durationMs: browserResult.durationMs,
+      measurements: browserResult.measurements,
+      target: {
+        origin: resolvedTarget.origin,
+        pages: resolvedTarget.pages.map((page) => page.displayPath),
+      },
+    });
+    const output =
+      outputFormat === "json"
+        ? `${JSON.stringify(report, null, 2)}\n`
+        : renderOverflowCheckReport(report, {
+            terminal: getOutputTerminalCapabilities(),
+          });
+
+    process.stdout.write(output);
+    if (report.status === "fail") {
+      process.exitCode = 1;
+    }
+  } finally {
+    process.removeListener("SIGINT", abortCheck);
+    process.removeListener("SIGTERM", abortCheck);
+  }
+};
+
 /**
  * The classification heuristic decides which packages feed the score, so it
  * needs to be inspectable without running a full audit.
@@ -579,12 +740,30 @@ const runScanAction = async (
   options: CliOptions,
   command: Command
 ): Promise<void> => {
+  validateFocusedOptions(options);
+  const outputFormat = resolveOutputFormat(options);
+
+  if (options.checkOverflow !== undefined) {
+    validateOverflowModeOptions({
+      command,
+      options,
+      outputFormat,
+      projectPath,
+    });
+    await runOverflowCheckAction({
+      browserExecutable: options.browserExecutable,
+      outputFormat,
+      routes: options.route,
+      target: options.checkOverflow,
+    });
+    return;
+  }
+
   if (options.listProjects) {
     await runListProjectsAction(projectPath, options);
     return;
   }
 
-  const outputFormat = resolveOutputFormat(options);
   validateScanActionOptions(options, outputFormat);
   const roastWasSpecified = command.getOptionValueSource("roast") === "cli";
   const includeRoast =
@@ -778,6 +957,19 @@ const createProgram = (): Command => {
       "Run only one audit category.",
       parseCategory
     )
+    .option(
+      "--check-overflow <url>",
+      "Check a running page for horizontal overflow at mobile and desktop widths."
+    )
+    .option(
+      "--route <path>",
+      "Add a same-origin route to --check-overflow (repeatable).",
+      collectRoute
+    )
+    .option(
+      "--browser-executable <path>",
+      "Use a specific Chromium executable for --check-overflow."
+    )
     .option("--no-roast", "Use neutral human output.")
     .option("--roast", "Force roast copy in CI and JSON output.")
     .option("--no-interactive", "Disable Shadscan follow-up prompts.")
@@ -806,7 +998,12 @@ const createProgram = (): Command => {
         "Apply the displayed pre-commit plan without prompting."
       ).conflicts("dryRun")
     )
-    .action(runSetupAction);
+    .action(
+      async (projectPath: string, options: SetupOptions, command: Command) => {
+        rejectFocusedOptionsForSubcommand(command);
+        await runSetupAction(projectPath, options);
+      }
+    );
 
   program
     .command("mcp")
@@ -814,7 +1011,8 @@ const createProgram = (): Command => {
       "Serve shadscan as an MCP server over stdio for coding agents."
     )
     .argument("[paths...]", "Root directories tool calls may scan.", undefined)
-    .action(async (paths: string[]) => {
+    .action(async (paths: string[], command: Command) => {
+      rejectFocusedOptionsForSubcommand(command);
       // stdout carries JSON-RPC exclusively in this mode; the server writes
       // its one startup line to stderr. Lazy import keeps the MCP bundle out
       // of ordinary scan startup.
@@ -849,5 +1047,6 @@ export {
   createProgram,
   resolveProjectPath,
   runCli,
+  runOverflowCheckAction,
   scoreFailsThreshold,
 };

--- a/packages/cli/src/overflow-check/browser-measure.ts
+++ b/packages/cli/src/overflow-check/browser-measure.ts
@@ -1,0 +1,322 @@
+// biome-ignore-all lint/complexity/noExcessiveCognitiveComplexity: The page evaluator stays closure-free so Playwright can serialize it safely.
+/// <reference lib="dom" />
+
+interface BrowserMeasurementLimits {
+  maxCulprits: number;
+  maxDescriptorLength: number;
+  maxElements: number;
+}
+
+interface BrowserOverflowCulprit {
+  depth: number;
+  descriptor: string;
+  left: number;
+  order: number;
+  overflowPx: number;
+  right: number;
+}
+
+interface BrowserOverflowMeasurement {
+  clientWidth: number;
+  culprits: BrowserOverflowCulprit[];
+  forcedScrollbar: boolean;
+  omittedCulprits: number;
+  scrollWidth: number;
+}
+
+type StabilityVector = [
+  clientWidth: number,
+  rootScrollWidth: number,
+  bodyScrollWidth: number,
+];
+
+/**
+ * Runs inside the audited page. Keep every helper inside this function because
+ * Playwright serializes the callback without its module scope.
+ */
+const measureDocumentOverflow = ({
+  maxCulprits,
+  maxDescriptorLength,
+  maxElements,
+}: BrowserMeasurementLimits): BrowserOverflowMeasurement => {
+  const root = document.documentElement;
+  const body = document.body;
+  const clientWidth = root.clientWidth;
+  const scrollWidth = Math.max(root.scrollWidth, body?.scrollWidth ?? 0);
+  const rootOverflowX = getComputedStyle(root).overflowX;
+  const bodyOverflowX = body ? getComputedStyle(body).overflowX : null;
+  const forcedScrollbar =
+    rootOverflowX === "scroll" || bodyOverflowX === "scroll";
+
+  if (!((scrollWidth > clientWidth || forcedScrollbar) && body)) {
+    return {
+      clientWidth,
+      culprits: [],
+      forcedScrollbar,
+      omittedCulprits: 0,
+      scrollWidth,
+    };
+  }
+
+  const containmentValues = new Set(["auto", "clip", "hidden", "scroll"]);
+  const maximumCoordinate = 10_000_000;
+  const maximumTokenLength = 48;
+  const maximumAncestryLevels = 4;
+
+  const boundNumber = (value: number): number => {
+    if (!Number.isFinite(value)) {
+      return 0;
+    }
+
+    return Math.max(-maximumCoordinate, Math.min(maximumCoordinate, value));
+  };
+
+  const sanitizeToken = (value: string): string =>
+    value
+      .normalize("NFKC")
+      .replace(/\p{Cc}/gu, "")
+      .replace(/[^a-zA-Z0-9_-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, maximumTokenLength);
+
+  const getParentElement = (element: Element): Element | null => {
+    if (element.parentElement) {
+      return element.parentElement;
+    }
+
+    const rootNode = element.getRootNode();
+    return rootNode instanceof ShadowRoot ? rootNode.host : null;
+  };
+
+  const formatDirectDescriptor = (element: Element): string | null => {
+    const dataSlot = sanitizeToken(element.getAttribute("data-slot") ?? "");
+    if (dataSlot) {
+      return `[data-slot="${dataSlot}"]`;
+    }
+
+    const id = sanitizeToken(element.id);
+    return id ? `#${id}` : null;
+  };
+
+  const formatElementSegment = (element: Element): string => {
+    const directDescriptor = formatDirectDescriptor(element);
+    if (directDescriptor) {
+      return directDescriptor;
+    }
+
+    const tagName = sanitizeToken(element.localName.toLowerCase()) || "element";
+    const classNames: string[] = [];
+
+    for (const rawClassName of Array.from(element.classList)) {
+      const className = sanitizeToken(rawClassName);
+      if (className && !classNames.includes(className)) {
+        classNames.push(className);
+      }
+      if (classNames.length === 2) {
+        break;
+      }
+    }
+
+    const parent = getParentElement(element);
+    const sameTagSiblings = parent
+      ? Array.from(parent.children).filter(
+          (sibling) => sibling.localName === element.localName
+        )
+      : [];
+    const siblingIndex = sameTagSiblings.indexOf(element);
+    const nthOfType =
+      sameTagSiblings.length > 1 && siblingIndex >= 0
+        ? `:nth-of-type(${siblingIndex + 1})`
+        : "";
+
+    return `${tagName}${classNames.map((name) => `.${name}`).join("")}${nthOfType}`;
+  };
+
+  const formatDescriptor = (element: Element): string => {
+    const directDescriptor = formatDirectDescriptor(element);
+    if (directDescriptor) {
+      return directDescriptor.slice(0, maxDescriptorLength);
+    }
+
+    const ancestry: string[] = [];
+    let currentElement: Element | null = element;
+
+    while (
+      currentElement &&
+      currentElement !== body &&
+      currentElement !== root &&
+      ancestry.length < maximumAncestryLevels
+    ) {
+      ancestry.unshift(formatElementSegment(currentElement));
+      const parent = getParentElement(currentElement);
+      if (parent) {
+        const parentDescriptor = formatDirectDescriptor(parent);
+        if (parentDescriptor) {
+          if (ancestry.length < maximumAncestryLevels) {
+            ancestry.unshift(parentDescriptor);
+          }
+          break;
+        }
+      }
+      currentElement = parent;
+    }
+
+    return ancestry.join(" > ").slice(0, maxDescriptorLength);
+  };
+
+  const getTraversalChildren = (
+    element: Element,
+    maximumChildren: number
+  ): Element[] => {
+    const children: Element[] = [];
+    const appendChildren = (collection: HTMLCollection): void => {
+      let index = 0;
+      while (index < collection.length && children.length < maximumChildren) {
+        const child = collection.item(index);
+        if (child) {
+          children.push(child);
+        }
+        index += 1;
+      }
+    };
+
+    if (element.shadowRoot) {
+      appendChildren(element.shadowRoot.children);
+    }
+    appendChildren(element.children);
+    return children;
+  };
+
+  const documentLeft = 0;
+  const documentRight = clientWidth;
+  const culpritCandidates: Array<
+    Omit<BrowserOverflowCulprit, "descriptor"> & { element: Element }
+  > = [];
+  const stack: Array<{
+    containedByAncestor: boolean;
+    depth: number;
+    element: Element;
+  }> = [{ containedByAncestor: false, depth: 0, element: body }];
+  let order = 0;
+
+  while (stack.length > 0 && order < maxElements) {
+    const entry = stack.pop();
+    if (!entry) {
+      break;
+    }
+
+    const { containedByAncestor, depth, element } = entry;
+    const traversalOrder = order;
+    order += 1;
+    const style = getComputedStyle(element);
+    const elementContainsDescendantOverflow =
+      element !== body &&
+      element !== root &&
+      (style.position === "fixed" || containmentValues.has(style.overflowX));
+
+    const remainingTraversalCapacity = Math.max(
+      0,
+      maxElements - order - stack.length
+    );
+    const children = getTraversalChildren(element, remainingTraversalCapacity);
+    for (
+      let childIndex = children.length - 1;
+      childIndex >= 0;
+      childIndex -= 1
+    ) {
+      const child = children[childIndex];
+      if (child) {
+        stack.push({
+          containedByAncestor:
+            containedByAncestor || elementContainsDescendantOverflow,
+          depth: depth + 1,
+          element: child,
+        });
+      }
+    }
+
+    if (element === body || element === root) {
+      continue;
+    }
+
+    if (style.position === "fixed" || containedByAncestor) {
+      continue;
+    }
+
+    const rectangle = element.getBoundingClientRect();
+    if (rectangle.width <= 0 || rectangle.height <= 0) {
+      continue;
+    }
+
+    const left = rectangle.left + window.scrollX;
+    const right = rectangle.right + window.scrollX;
+    const edgeOverflow = Math.max(
+      0,
+      documentLeft - left,
+      right - documentRight
+    );
+    const internalOverflow =
+      style.overflowX === "visible"
+        ? Math.max(0, element.scrollWidth - element.clientWidth)
+        : 0;
+    const overflowPx = Math.max(edgeOverflow, internalOverflow);
+
+    if (overflowPx <= 0) {
+      continue;
+    }
+
+    culpritCandidates.push({
+      depth,
+      element,
+      left: boundNumber(left),
+      order: traversalOrder,
+      overflowPx: boundNumber(overflowPx),
+      right: boundNumber(right),
+    });
+  }
+
+  culpritCandidates.sort(
+    (first, second) =>
+      second.overflowPx - first.overflowPx ||
+      second.depth - first.depth ||
+      first.order - second.order
+  );
+  const culprits = culpritCandidates
+    .slice(0, maxCulprits)
+    .map(({ element, ...culprit }) => ({
+      ...culprit,
+      descriptor: formatDescriptor(element),
+    }));
+
+  return {
+    clientWidth,
+    culprits,
+    forcedScrollbar,
+    omittedCulprits: Math.max(0, culpritCandidates.length - maxCulprits),
+    scrollWidth,
+  };
+};
+
+const readDocumentWidthVector = (): StabilityVector => {
+  const root = document.documentElement;
+  return [root.clientWidth, root.scrollWidth, document.body?.scrollWidth ?? 0];
+};
+
+const waitForTwoAnimationFrames = (): Promise<void> =>
+  new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+
+export type {
+  BrowserMeasurementLimits,
+  BrowserOverflowCulprit,
+  BrowserOverflowMeasurement,
+  StabilityVector,
+};
+export {
+  measureDocumentOverflow,
+  readDocumentWidthVector,
+  waitForTwoAnimationFrames,
+};

--- a/packages/cli/src/overflow-check/browser.ts
+++ b/packages/cli/src/overflow-check/browser.ts
@@ -1,0 +1,617 @@
+import type {
+  Browser,
+  BrowserType,
+  Page,
+  Request,
+  Response,
+} from "playwright-core";
+import {
+  type BrowserOverflowMeasurement,
+  measureDocumentOverflow,
+  readDocumentWidthVector,
+  type StabilityVector,
+  waitForTwoAnimationFrames,
+} from "./browser-measure";
+import type { OverflowMeasurementInput, OverflowViewport } from "./contracts";
+import {
+  MAX_OVERFLOW_REPORT_PATH_LENGTH,
+  OVERFLOW_VIEWPORTS,
+} from "./contracts";
+import { OverflowCheckError } from "./error";
+import type { ResolvedOverflowPage } from "./options";
+
+const DEFAULT_CHECK_TIMEOUT_MS = 60_000;
+const NAVIGATION_TIMEOUT_MS = 15_000;
+const HYDRATION_WAIT_MS = 750;
+const STABILITY_INTERVAL_MS = 100;
+const REQUIRED_STABLE_INTERVALS = 5;
+const STABILITY_TIMEOUT_MS = 5000;
+const MAX_ELEMENTS = 20_000;
+const MAX_CULPRITS = 3;
+const MAX_DESCRIPTOR_LENGTH = 160;
+const HTML_CONTENT_TYPE_PATTERN =
+  /^(?:text\/html|application\/xhtml\+xml)(?:\s*;|$)/i;
+const CONTROL_CHARACTER_PATTERN = /\p{Cc}/gu;
+const BROWSER_INSTALL_COMMAND =
+  "pnpm dlx playwright-core@1.61.1 install chromium";
+
+type OverflowBrowserPage = ResolvedOverflowPage;
+
+interface RunOverflowBrowserCheckOptions {
+  browserExecutable?: string;
+  origin: string;
+  pages: readonly OverflowBrowserPage[];
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
+interface OverflowBrowserMetadata {
+  name: string;
+  version: string;
+}
+
+interface OverflowBrowserCheckResult {
+  browser: OverflowBrowserMetadata;
+  durationMs: number;
+  measurements: OverflowMeasurementInput[];
+}
+
+interface LoadedPlaywright {
+  chromium: BrowserType;
+}
+
+interface OverflowBrowserDependencies {
+  loadPlaywright: () => Promise<LoadedPlaywright>;
+  now: () => number;
+  wait: (durationMs: number) => Promise<void>;
+}
+
+interface LaunchedBrowser {
+  browser: Browser;
+  name: string;
+}
+
+interface BrowserLaunchAttempt {
+  channel?: "chrome" | "msedge";
+  executablePath?: string;
+  name: string;
+}
+
+interface MeasurementContext {
+  deadline: number;
+  dependencies: OverflowBrowserDependencies;
+  origin: string;
+  signal?: AbortSignal;
+}
+
+const defaultDependencies: OverflowBrowserDependencies = {
+  loadPlaywright: async () => import("playwright-core"),
+  now: Date.now,
+  wait: (durationMs) =>
+    new Promise((resolve) => {
+      setTimeout(resolve, durationMs);
+    }),
+};
+
+const createCheckError = (
+  code:
+    | "OVERFLOW_BROWSER_UNAVAILABLE"
+    | "OVERFLOW_TARGET_UNAVAILABLE"
+    | "OVERFLOW_CHECK_TIMEOUT"
+    | "OVERFLOW_PAGE_NOT_STABLE"
+    | "OVERFLOW_CHECK_FAILED",
+  message: string
+): OverflowCheckError => new OverflowCheckError(code, message);
+
+const throwIfInterrupted = (signal: AbortSignal | undefined): void => {
+  if (signal?.aborted) {
+    throw createCheckError(
+      "OVERFLOW_CHECK_FAILED",
+      "The horizontal overflow check was interrupted."
+    );
+  }
+};
+
+const remainingTime = (
+  deadline: number,
+  dependencies: OverflowBrowserDependencies
+): number => Math.max(0, deadline - dependencies.now());
+
+const throwIfTimedOut = (
+  deadline: number,
+  dependencies: OverflowBrowserDependencies
+): void => {
+  if (remainingTime(deadline, dependencies) <= 0) {
+    throw createCheckError(
+      "OVERFLOW_CHECK_TIMEOUT",
+      "The horizontal overflow check exceeded its 60 second deadline."
+    );
+  }
+};
+
+const runBeforeDeadline = async <Result>(
+  operation: Promise<Result>,
+  context: Pick<MeasurementContext, "deadline" | "dependencies" | "signal">,
+  timeoutMessage = "The horizontal overflow check exceeded its 60 second deadline."
+): Promise<Result> => {
+  const { deadline, dependencies, signal } = context;
+  throwIfInterrupted(signal);
+  throwIfTimedOut(deadline, dependencies);
+
+  return await new Promise<Result>((resolve, reject) => {
+    const timeout = setTimeout(
+      () => {
+        reject(createCheckError("OVERFLOW_CHECK_TIMEOUT", timeoutMessage));
+      },
+      remainingTime(deadline, dependencies)
+    );
+    const onAbort = (): void => {
+      reject(
+        createCheckError(
+          "OVERFLOW_CHECK_FAILED",
+          "The horizontal overflow check was interrupted."
+        )
+      );
+    };
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+    operation.then(
+      (result) => {
+        cleanup();
+        resolve(result);
+      },
+      (error: unknown) => {
+        cleanup();
+        reject(error);
+      }
+    );
+  });
+};
+
+const sanitizeReportPath = (url: string): string => {
+  try {
+    return new URL(url).pathname
+      .replace(CONTROL_CHARACTER_PATTERN, "")
+      .slice(0, MAX_OVERFLOW_REPORT_PATH_LENGTH);
+  } catch {
+    return "/";
+  }
+};
+
+const sanitizeDisplayPath = (path: string): string =>
+  path
+    .replace(CONTROL_CHARACTER_PATTERN, "")
+    .slice(0, MAX_OVERFLOW_REPORT_PATH_LENGTH);
+
+const isSameOrigin = (url: string, expectedOrigin: string): boolean => {
+  try {
+    const parsedUrl = new URL(url);
+    const isHttpPage =
+      parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
+    return (
+      isHttpPage &&
+      parsedUrl.username === "" &&
+      parsedUrl.password === "" &&
+      parsedUrl.origin === expectedOrigin
+    );
+  } catch {
+    return false;
+  }
+};
+
+const isSuccessfulHtmlResponse = (response: Response): boolean => {
+  const status = response.status();
+  const contentType = response.headers()["content-type"] ?? "";
+  return (
+    status >= 200 && status < 300 && HTML_CONTENT_TYPE_PATTERN.test(contentType)
+  );
+};
+
+const hasOnlySameOriginRedirects = (
+  response: Response,
+  expectedOrigin: string
+): boolean => {
+  let request: Request | null = response.request();
+
+  while (request) {
+    if (!isSameOrigin(request.url(), expectedOrigin)) {
+      return false;
+    }
+    request = request.redirectedFrom();
+  }
+
+  return true;
+};
+
+const vectorsMatch = (
+  first: StabilityVector,
+  second: StabilityVector
+): boolean =>
+  first[0] === second[0] && first[1] === second[1] && first[2] === second[2];
+
+const waitForStableDocumentWidth = async (
+  page: Page,
+  context: MeasurementContext
+): Promise<void> => {
+  const { deadline, dependencies, signal } = context;
+  const stabilityDeadline = Math.min(
+    deadline,
+    dependencies.now() + STABILITY_TIMEOUT_MS
+  );
+  let previousVector = await runBeforeDeadline(
+    page.evaluate(readDocumentWidthVector),
+    context
+  );
+  let stableIntervals = 0;
+
+  while (dependencies.now() < stabilityDeadline) {
+    throwIfInterrupted(signal);
+    const waitDuration = Math.min(
+      STABILITY_INTERVAL_MS,
+      stabilityDeadline - dependencies.now()
+    );
+    await runBeforeDeadline(dependencies.wait(waitDuration), context);
+    const currentVector = await runBeforeDeadline(
+      page.evaluate(readDocumentWidthVector),
+      context
+    );
+
+    stableIntervals = vectorsMatch(previousVector, currentVector)
+      ? stableIntervals + 1
+      : 0;
+    if (stableIntervals >= REQUIRED_STABLE_INTERVALS) {
+      return;
+    }
+    previousVector = currentVector;
+  }
+
+  throwIfTimedOut(deadline, dependencies);
+  throw createCheckError(
+    "OVERFLOW_PAGE_NOT_STABLE",
+    "The page width did not settle within 5 seconds."
+  );
+};
+
+const waitForPageReadiness = async (
+  page: Page,
+  context: MeasurementContext
+): Promise<void> => {
+  await runBeforeDeadline(page.evaluate("document.fonts.ready"), context);
+  await runBeforeDeadline(
+    context.dependencies.wait(HYDRATION_WAIT_MS),
+    context
+  );
+  await waitForStableDocumentWidth(page, context);
+  await runBeforeDeadline(page.evaluate(waitForTwoAnimationFrames), context);
+};
+
+const toMeasurementInput = ({
+  browserMeasurement,
+  finalPath,
+  httpStatus,
+  reportPath,
+  viewport,
+}: {
+  browserMeasurement: BrowserOverflowMeasurement;
+  finalPath: string;
+  httpStatus: number;
+  reportPath: string;
+  viewport: OverflowViewport;
+}): OverflowMeasurementInput => ({
+  clientWidth: browserMeasurement.clientWidth,
+  culprits: browserMeasurement.culprits,
+  finalPath,
+  forcedScrollbar: browserMeasurement.forcedScrollbar,
+  httpStatus,
+  omittedCulprits: browserMeasurement.omittedCulprits,
+  page: reportPath,
+  scrollWidth: browserMeasurement.scrollWidth,
+  viewport,
+});
+
+const navigateAndMeasure = async ({
+  browser,
+  context,
+  page: targetPage,
+  viewport,
+}: {
+  browser: Browser;
+  context: MeasurementContext;
+  page: OverflowBrowserPage;
+  viewport: OverflowViewport;
+}): Promise<OverflowMeasurementInput> => {
+  const browserContext = await runBeforeDeadline(
+    browser.newContext({
+      acceptDownloads: false,
+      colorScheme: "light",
+      deviceScaleFactor: 1,
+      serviceWorkers: "block",
+      viewport: { height: viewport.height, width: viewport.width },
+    }),
+    context
+  );
+  const unexpectedPageClosures: Promise<unknown>[] = [];
+
+  try {
+    const page = await runBeforeDeadline(browserContext.newPage(), context);
+    const displayPath = sanitizeDisplayPath(targetPage.displayPath);
+    let crossOriginMainNavigation = false;
+    let latestMainFrameResponse: Response | null = null;
+    await runBeforeDeadline(
+      page.route("**/*", async (route) => {
+        const request = route.request();
+        if (
+          request.isNavigationRequest() &&
+          request.frame() === page.mainFrame() &&
+          !isSameOrigin(request.url(), context.origin)
+        ) {
+          crossOriginMainNavigation = true;
+          await route.abort("blockedbyclient");
+          return;
+        }
+
+        await route.continue();
+      }),
+      context
+    );
+    page.on("response", (observedResponse) => {
+      const request = observedResponse.request();
+      if (
+        request.isNavigationRequest() &&
+        request.frame() === page.mainFrame()
+      ) {
+        latestMainFrameResponse = observedResponse;
+      }
+    });
+    browserContext.on("page", (openedPage) => {
+      if (openedPage !== page) {
+        unexpectedPageClosures.push(openedPage.close().catch(() => undefined));
+      }
+    });
+    const throwIfCrossOriginNavigation = (): void => {
+      if (
+        crossOriginMainNavigation ||
+        !isSameOrigin(page.url(), context.origin)
+      ) {
+        throw createCheckError(
+          "OVERFLOW_TARGET_UNAVAILABLE",
+          `The target page ${displayPath} attempted a cross-origin navigation.`
+        );
+      }
+    };
+    const getValidatedMainFrameResponse = (): Response => {
+      throwIfCrossOriginNavigation();
+      const settledResponse = latestMainFrameResponse;
+      const responseIsValid =
+        settledResponse !== null &&
+        isSuccessfulHtmlResponse(settledResponse) &&
+        hasOnlySameOriginRedirects(settledResponse, context.origin);
+      if (!responseIsValid) {
+        throw createCheckError(
+          "OVERFLOW_TARGET_UNAVAILABLE",
+          `The target page ${displayPath} did not return same-origin HTML with a successful status.`
+        );
+      }
+      return settledResponse;
+    };
+    const navigationTimeout = Math.min(
+      NAVIGATION_TIMEOUT_MS,
+      remainingTime(context.deadline, context.dependencies)
+    );
+    let response: Response | null;
+
+    try {
+      response = await page.goto(targetPage.requestedUrl, {
+        timeout: navigationTimeout,
+        waitUntil: "load",
+      });
+    } catch (error) {
+      throwIfInterrupted(context.signal);
+      throwIfTimedOut(context.deadline, context.dependencies);
+      throwIfCrossOriginNavigation();
+      if (error instanceof Error && error.name === "TimeoutError") {
+        throw createCheckError(
+          "OVERFLOW_CHECK_TIMEOUT",
+          `The target page ${displayPath} did not load within 15 seconds.`
+        );
+      }
+      throw createCheckError(
+        "OVERFLOW_TARGET_UNAVAILABLE",
+        `The target page ${displayPath} could not be loaded.`
+      );
+    }
+
+    if (latestMainFrameResponse === null) {
+      latestMainFrameResponse = response;
+    }
+    getValidatedMainFrameResponse();
+
+    await waitForPageReadiness(page, context);
+    getValidatedMainFrameResponse();
+    let browserMeasurement: BrowserOverflowMeasurement;
+    try {
+      browserMeasurement = await runBeforeDeadline(
+        page.evaluate(measureDocumentOverflow, {
+          maxCulprits: MAX_CULPRITS,
+          maxDescriptorLength: MAX_DESCRIPTOR_LENGTH,
+          maxElements: MAX_ELEMENTS,
+        }),
+        context
+      );
+    } catch (error) {
+      throwIfCrossOriginNavigation();
+      throw error;
+    }
+    const finalResponse = getValidatedMainFrameResponse();
+
+    return toMeasurementInput({
+      browserMeasurement,
+      finalPath: sanitizeReportPath(page.url()),
+      httpStatus: finalResponse.status(),
+      reportPath: targetPage.displayPath,
+      viewport,
+    });
+  } finally {
+    await Promise.allSettled(unexpectedPageClosures);
+    await browserContext.close().catch(() => undefined);
+  }
+};
+
+const createLaunchAttempts = (
+  browserExecutable: string | undefined
+): BrowserLaunchAttempt[] => {
+  if (browserExecutable) {
+    return [{ executablePath: browserExecutable, name: "chromium" }];
+  }
+
+  return [
+    { name: "chromium" },
+    { channel: "chrome", name: "chrome" },
+    { channel: "msedge", name: "msedge" },
+  ];
+};
+
+const launchBrowser = async (
+  chromium: BrowserType,
+  browserExecutable: string | undefined,
+  context: MeasurementContext
+): Promise<LaunchedBrowser> => {
+  for (const attempt of createLaunchAttempts(browserExecutable)) {
+    throwIfInterrupted(context.signal);
+    throwIfTimedOut(context.deadline, context.dependencies);
+
+    try {
+      const browser = await chromium.launch({
+        channel: attempt.channel,
+        executablePath: attempt.executablePath,
+        headless: true,
+        timeout: Math.min(
+          NAVIGATION_TIMEOUT_MS,
+          remainingTime(context.deadline, context.dependencies)
+        ),
+      });
+      if (context.signal?.aborted) {
+        await browser.close().catch(() => undefined);
+        throwIfInterrupted(context.signal);
+      }
+      return { browser, name: attempt.name };
+    } catch (error) {
+      if (error instanceof OverflowCheckError) {
+        throw error;
+      }
+    }
+  }
+
+  throw createCheckError(
+    "OVERFLOW_BROWSER_UNAVAILABLE",
+    `No supported Chromium browser is available. Install one with: ${BROWSER_INSTALL_COMMAND}`
+  );
+};
+
+const runOverflowBrowserCheck = async (
+  {
+    browserExecutable,
+    origin,
+    pages,
+    signal,
+    timeoutMs = DEFAULT_CHECK_TIMEOUT_MS,
+  }: RunOverflowBrowserCheckOptions,
+  dependencies: OverflowBrowserDependencies = defaultDependencies
+): Promise<OverflowBrowserCheckResult> => {
+  const startedAt = dependencies.now();
+  const deadline = startedAt + timeoutMs;
+  const context: MeasurementContext = {
+    deadline,
+    dependencies,
+    origin,
+    signal,
+  };
+  let playwright: LoadedPlaywright;
+
+  try {
+    playwright = await runBeforeDeadline(
+      dependencies.loadPlaywright(),
+      context
+    );
+  } catch (error) {
+    if (error instanceof OverflowCheckError) {
+      throw error;
+    }
+    throw createCheckError(
+      "OVERFLOW_BROWSER_UNAVAILABLE",
+      `The Chromium runtime could not be loaded. Install it with: ${BROWSER_INSTALL_COMMAND}`
+    );
+  }
+
+  const launchedBrowser = await launchBrowser(
+    playwright.chromium,
+    browserExecutable,
+    context
+  );
+
+  try {
+    try {
+      const measurements: OverflowMeasurementInput[] = [];
+
+      for (const targetPage of pages) {
+        throwIfInterrupted(signal);
+        throwIfTimedOut(deadline, dependencies);
+        const settledMeasurements = await Promise.allSettled(
+          OVERFLOW_VIEWPORTS.map((viewport) =>
+            navigateAndMeasure({
+              browser: launchedBrowser.browser,
+              context,
+              page: targetPage,
+              viewport,
+            })
+          )
+        );
+        const rejectedMeasurement = settledMeasurements.find(
+          (result) => result.status === "rejected"
+        );
+
+        if (rejectedMeasurement?.status === "rejected") {
+          throw rejectedMeasurement.reason;
+        }
+
+        for (const result of settledMeasurements) {
+          if (result.status === "fulfilled") {
+            measurements.push(result.value);
+          }
+        }
+      }
+
+      return {
+        browser: {
+          name: launchedBrowser.name,
+          version: launchedBrowser.browser.version(),
+        },
+        durationMs: Math.max(0, dependencies.now() - startedAt),
+        measurements,
+      };
+    } catch (error) {
+      if (error instanceof OverflowCheckError) {
+        throw error;
+      }
+      throw createCheckError(
+        "OVERFLOW_CHECK_FAILED",
+        "The browser could not complete the horizontal overflow check."
+      );
+    }
+  } finally {
+    await launchedBrowser.browser.close().catch(() => undefined);
+  }
+};
+
+export type {
+  OverflowBrowserCheckResult,
+  OverflowBrowserDependencies,
+  OverflowBrowserMetadata,
+  OverflowBrowserPage,
+  RunOverflowBrowserCheckOptions,
+};
+export { runOverflowBrowserCheck, sanitizeReportPath };

--- a/packages/cli/src/overflow-check/contracts.ts
+++ b/packages/cli/src/overflow-check/contracts.ts
@@ -1,0 +1,292 @@
+import { z } from "zod";
+import packageJson from "../../package.json";
+
+const OVERFLOW_CHECK_SCHEMA_VERSION = 1 as const;
+const OVERFLOW_CHECK_KIND = "overflow-check" as const;
+const OVERFLOW_CHECK_SEVERITY = "critical" as const;
+const OVERFLOW_ENGINE_VERSION = packageJson.version;
+const MAX_OVERFLOW_PAGES = 10;
+const MAX_OVERFLOW_RESULTS = MAX_OVERFLOW_PAGES * 2;
+const MAX_OVERFLOW_CULPRITS = 3;
+const MAX_OVERFLOW_URL_LENGTH = 2048;
+const MAX_OVERFLOW_REPORT_PATH_LENGTH = 1024;
+const MAX_CULPRIT_DESCRIPTOR_LENGTH = 160;
+const MAX_MEASUREMENT_VALUE = 100_000_000;
+const MAX_DURATION_MS = 300_000;
+const OVERFLOW_REMEDIATION =
+  "Fix document-level overflow by constraining wide content, adding min-width: 0 to shrinking flex or grid children, wrapping long values, or using a bounded local scroller. Do not hide overflow on html or body; fix the element that expands the document.";
+
+const OVERFLOW_VIEWPORTS = [
+  { height: 820, name: "mobile", width: 320 },
+  { height: 1000, name: "desktop", width: 1440 },
+] as const;
+
+const MobileViewportSchema = z.object({
+  height: z.literal(820),
+  name: z.literal("mobile"),
+  width: z.literal(320),
+});
+
+const DesktopViewportSchema = z.object({
+  height: z.literal(1000),
+  name: z.literal("desktop"),
+  width: z.literal(1440),
+});
+
+const OverflowViewportSchema = z.discriminatedUnion("name", [
+  MobileViewportSchema,
+  DesktopViewportSchema,
+]);
+
+const BoundedMeasurementSchema = z
+  .number()
+  .finite()
+  .min(-MAX_MEASUREMENT_VALUE)
+  .max(MAX_MEASUREMENT_VALUE);
+
+const NonNegativeMeasurementSchema = BoundedMeasurementSchema.nonnegative();
+const ReportPathSchema = z
+  .string()
+  .min(1)
+  .max(MAX_OVERFLOW_REPORT_PATH_LENGTH)
+  .startsWith("/");
+const OverflowOriginSchema = z
+  .string()
+  .url()
+  .max(MAX_OVERFLOW_URL_LENGTH)
+  .refine((origin) => {
+    try {
+      const url = new URL(origin);
+      return (
+        (url.protocol === "http:" || url.protocol === "https:") &&
+        url.username === "" &&
+        url.password === "" &&
+        url.origin === origin
+      );
+    } catch {
+      return false;
+    }
+  }, "Expected an HTTP or HTTPS origin without credentials.");
+
+const OverflowCulpritSchema = z.object({
+  descriptor: z.string().min(1).max(MAX_CULPRIT_DESCRIPTOR_LENGTH),
+  left: BoundedMeasurementSchema,
+  overflowPx: NonNegativeMeasurementSchema,
+  right: BoundedMeasurementSchema,
+});
+
+const OverflowMeasurementSchema = z
+  .object({
+    clientWidth: NonNegativeMeasurementSchema.int(),
+    culprits: z.array(OverflowCulpritSchema).max(MAX_OVERFLOW_CULPRITS),
+    finalPath: ReportPathSchema,
+    forcedScrollbar: z.boolean(),
+    httpStatus: z.number().int().min(100).max(599),
+    omittedCulprits: z.number().int().nonnegative().max(20_000),
+    overflowPx: NonNegativeMeasurementSchema.int(),
+    page: ReportPathSchema,
+    scrollWidth: NonNegativeMeasurementSchema.int(),
+    status: z.enum(["fail", "pass"]),
+    viewport: OverflowViewportSchema,
+  })
+  .superRefine((measurement, context) => {
+    const expectedOverflow = Math.max(
+      0,
+      measurement.scrollWidth - measurement.clientWidth
+    );
+    const expectedStatus =
+      expectedOverflow > 0 || measurement.forcedScrollbar ? "fail" : "pass";
+
+    if (measurement.overflowPx !== expectedOverflow) {
+      context.addIssue({
+        code: "custom",
+        message: "overflowPx must match scrollWidth - clientWidth.",
+        path: ["overflowPx"],
+      });
+    }
+
+    if (measurement.status !== expectedStatus) {
+      context.addIssue({
+        code: "custom",
+        message: "status must reflect document overflow.",
+        path: ["status"],
+      });
+    }
+
+    if (measurement.status === "pass" && measurement.culprits.length > 0) {
+      context.addIssue({
+        code: "custom",
+        message: "Passing measurements cannot contain culprits.",
+        path: ["culprits"],
+      });
+    }
+  });
+
+const OverflowTargetSchema = z
+  .object({
+    origin: OverflowOriginSchema,
+    pages: z.array(ReportPathSchema).min(1).max(MAX_OVERFLOW_PAGES),
+  })
+  .superRefine((target, context) => {
+    if (new Set(target.pages).size !== target.pages.length) {
+      context.addIssue({
+        code: "custom",
+        message: "Target pages must be unique.",
+        path: ["pages"],
+      });
+    }
+  });
+
+const OverflowSummarySchema = z.object({
+  failed: z.number().int().nonnegative().max(MAX_OVERFLOW_RESULTS),
+  maximumOverflowPx: NonNegativeMeasurementSchema.int(),
+  measurements: z.number().int().min(1).max(MAX_OVERFLOW_RESULTS),
+});
+
+const OverflowCheckReportSchema = z
+  .object({
+    durationMs: z.number().finite().nonnegative().max(MAX_DURATION_MS),
+    engineVersion: z.string().min(1).max(64),
+    kind: z.literal(OVERFLOW_CHECK_KIND),
+    remediation: z.string().min(1).max(500).nullable(),
+    results: z
+      .array(OverflowMeasurementSchema)
+      .min(1)
+      .max(MAX_OVERFLOW_RESULTS),
+    schemaVersion: z.literal(OVERFLOW_CHECK_SCHEMA_VERSION),
+    severity: z.literal(OVERFLOW_CHECK_SEVERITY),
+    status: z.enum(["fail", "pass"]),
+    summary: OverflowSummarySchema,
+    target: OverflowTargetSchema,
+    viewports: z.tuple([MobileViewportSchema, DesktopViewportSchema]),
+  })
+  .superRefine((report, context) => {
+    const failed = report.results.filter(
+      (measurement) => measurement.status === "fail"
+    ).length;
+    const maximumOverflowPx = Math.max(
+      ...report.results.map((measurement) => measurement.overflowPx)
+    );
+    const expectedStatus = failed > 0 ? "fail" : "pass";
+
+    if (report.summary.measurements !== report.results.length) {
+      context.addIssue({
+        code: "custom",
+        message: "summary.measurements must match the result count.",
+        path: ["summary", "measurements"],
+      });
+    }
+
+    if (report.summary.failed !== failed) {
+      context.addIssue({
+        code: "custom",
+        message: "summary.failed must match the failed result count.",
+        path: ["summary", "failed"],
+      });
+    }
+
+    if (report.summary.maximumOverflowPx !== maximumOverflowPx) {
+      context.addIssue({
+        code: "custom",
+        message: "summary.maximumOverflowPx must match the results.",
+        path: ["summary", "maximumOverflowPx"],
+      });
+    }
+
+    if (report.status !== expectedStatus) {
+      context.addIssue({
+        code: "custom",
+        message: "status must reflect failed measurements.",
+        path: ["status"],
+      });
+    }
+
+    if (
+      (report.status === "pass" && report.remediation !== null) ||
+      (report.status === "fail" && report.remediation === null)
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "remediation must be present only for failed reports.",
+        path: ["remediation"],
+      });
+    }
+
+    const expectedMeasurementCount =
+      report.target.pages.length * OVERFLOW_VIEWPORTS.length;
+    const matrixIsComplete =
+      report.results.length === expectedMeasurementCount &&
+      report.target.pages.every((page, pageIndex) =>
+        OVERFLOW_VIEWPORTS.every((viewport, viewportIndex) => {
+          const resultIndex =
+            pageIndex * OVERFLOW_VIEWPORTS.length + viewportIndex;
+          const result = report.results[resultIndex];
+          return (
+            result?.page === page &&
+            result.viewport.name === viewport.name &&
+            result.viewport.width === viewport.width &&
+            result.viewport.height === viewport.height
+          );
+        })
+      );
+
+    if (!matrixIsComplete) {
+      context.addIssue({
+        code: "custom",
+        message:
+          "Results must contain mobile and desktop measurements per page.",
+        path: ["results"],
+      });
+    }
+  });
+
+type OverflowViewport = z.infer<typeof OverflowViewportSchema>;
+type OverflowCulprit = z.infer<typeof OverflowCulpritSchema>;
+type OverflowMeasurement = z.infer<typeof OverflowMeasurementSchema>;
+type OverflowCheckReport = z.infer<typeof OverflowCheckReportSchema>;
+type OverflowTarget = z.infer<typeof OverflowTargetSchema>;
+
+interface OverflowCulpritCandidate extends OverflowCulprit {
+  depth: number;
+  order: number;
+}
+
+interface OverflowMeasurementInput {
+  clientWidth: number;
+  culprits?: OverflowCulpritCandidate[];
+  finalPath: string;
+  forcedScrollbar: boolean;
+  httpStatus: number;
+  omittedCulprits?: number;
+  page: string;
+  scrollWidth: number;
+  viewport: OverflowViewport;
+}
+
+export type {
+  OverflowCheckReport,
+  OverflowCulprit,
+  OverflowCulpritCandidate,
+  OverflowMeasurement,
+  OverflowMeasurementInput,
+  OverflowTarget,
+  OverflowViewport,
+};
+export {
+  MAX_CULPRIT_DESCRIPTOR_LENGTH,
+  MAX_OVERFLOW_CULPRITS,
+  MAX_OVERFLOW_PAGES,
+  MAX_OVERFLOW_REPORT_PATH_LENGTH,
+  MAX_OVERFLOW_URL_LENGTH,
+  OVERFLOW_CHECK_KIND,
+  OVERFLOW_CHECK_SCHEMA_VERSION,
+  OVERFLOW_CHECK_SEVERITY,
+  OVERFLOW_ENGINE_VERSION,
+  OVERFLOW_REMEDIATION,
+  OVERFLOW_VIEWPORTS,
+  OverflowCheckReportSchema,
+  OverflowCulpritSchema,
+  OverflowMeasurementSchema,
+  OverflowTargetSchema,
+  OverflowViewportSchema,
+};

--- a/packages/cli/src/overflow-check/error.ts
+++ b/packages/cli/src/overflow-check/error.ts
@@ -1,0 +1,23 @@
+const OVERFLOW_CHECK_ERROR_CODES = [
+  "INVALID_ARGUMENTS",
+  "OVERFLOW_BROWSER_UNAVAILABLE",
+  "OVERFLOW_TARGET_UNAVAILABLE",
+  "OVERFLOW_CHECK_TIMEOUT",
+  "OVERFLOW_PAGE_NOT_STABLE",
+  "OVERFLOW_CHECK_FAILED",
+] as const;
+
+type OverflowCheckErrorCode = (typeof OVERFLOW_CHECK_ERROR_CODES)[number];
+
+class OverflowCheckError extends Error {
+  readonly code: OverflowCheckErrorCode;
+
+  constructor(code: OverflowCheckErrorCode, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "OverflowCheckError";
+  }
+}
+
+export type { OverflowCheckErrorCode };
+export { OVERFLOW_CHECK_ERROR_CODES, OverflowCheckError };

--- a/packages/cli/src/overflow-check/evaluate.ts
+++ b/packages/cli/src/overflow-check/evaluate.ts
@@ -1,0 +1,170 @@
+import { compareCodeUnits } from "../deterministic-order";
+import { sanitizeTerminalText } from "../render-human";
+import {
+  MAX_CULPRIT_DESCRIPTOR_LENGTH,
+  MAX_OVERFLOW_CULPRITS,
+  OVERFLOW_CHECK_KIND,
+  OVERFLOW_CHECK_SCHEMA_VERSION,
+  OVERFLOW_CHECK_SEVERITY,
+  OVERFLOW_ENGINE_VERSION,
+  OVERFLOW_REMEDIATION,
+  OVERFLOW_VIEWPORTS,
+  type OverflowCheckReport,
+  OverflowCheckReportSchema,
+  type OverflowCulprit,
+  type OverflowCulpritCandidate,
+  type OverflowMeasurement,
+  type OverflowMeasurementInput,
+  type OverflowTarget,
+} from "./contracts";
+import { OverflowCheckError } from "./error";
+
+interface EvaluateOverflowCheckOptions {
+  durationMs: number;
+  measurements: OverflowMeasurementInput[];
+  target: OverflowTarget;
+}
+
+const throwInvalidMeasurement = (): never => {
+  throw new OverflowCheckError(
+    "OVERFLOW_CHECK_FAILED",
+    "The browser returned an invalid horizontal overflow measurement."
+  );
+};
+
+const sanitizeDescriptor = (descriptor: string): string => {
+  const sanitized = sanitizeTerminalText(descriptor)
+    .replaceAll(/\s+/gu, " ")
+    .trim()
+    .slice(0, MAX_CULPRIT_DESCRIPTOR_LENGTH);
+
+  return sanitized === "" ? "unknown element" : sanitized;
+};
+
+const compareCulprits = (
+  left: OverflowCulpritCandidate,
+  right: OverflowCulpritCandidate
+): number =>
+  right.overflowPx - left.overflowPx ||
+  right.depth - left.depth ||
+  left.order - right.order ||
+  compareCodeUnits(left.descriptor, right.descriptor);
+
+const normalizeOverflowCulprits = (
+  candidates: OverflowCulpritCandidate[]
+): OverflowCulprit[] =>
+  [...candidates]
+    .sort(compareCulprits)
+    .slice(0, MAX_OVERFLOW_CULPRITS)
+    .map(({ descriptor, left, overflowPx, right }) => ({
+      descriptor: sanitizeDescriptor(descriptor),
+      left,
+      overflowPx: Math.max(0, overflowPx),
+      right,
+    }));
+
+const createOverflowMeasurement = (
+  input: OverflowMeasurementInput
+): OverflowMeasurement => {
+  const overflowPx = Math.max(0, input.scrollWidth - input.clientWidth);
+  const status =
+    overflowPx > 0 || input.forcedScrollbar
+      ? ("fail" as const)
+      : ("pass" as const);
+  const candidates = status === "fail" ? (input.culprits ?? []) : [];
+  const omittedByCore = Math.max(0, candidates.length - MAX_OVERFLOW_CULPRITS);
+
+  return {
+    clientWidth: input.clientWidth,
+    culprits: normalizeOverflowCulprits(candidates),
+    finalPath: input.finalPath,
+    forcedScrollbar: input.forcedScrollbar,
+    httpStatus: input.httpStatus,
+    omittedCulprits:
+      status === "fail"
+        ? Math.max(input.omittedCulprits ?? 0, omittedByCore)
+        : 0,
+    overflowPx,
+    page: input.page,
+    scrollWidth: input.scrollWidth,
+    status,
+    viewport: input.viewport,
+  };
+};
+
+const validateMeasurementMatrix = (
+  target: OverflowTarget,
+  measurements: OverflowMeasurementInput[]
+): void => {
+  const expectedMeasurementCount =
+    target.pages.length * OVERFLOW_VIEWPORTS.length;
+  if (measurements.length !== expectedMeasurementCount) {
+    throwInvalidMeasurement();
+  }
+
+  for (const [pageIndex, page] of target.pages.entries()) {
+    for (const [viewportIndex, viewport] of OVERFLOW_VIEWPORTS.entries()) {
+      const measurementIndex =
+        pageIndex * OVERFLOW_VIEWPORTS.length + viewportIndex;
+      const measurement = measurements[measurementIndex];
+      if (!measurement) {
+        throwInvalidMeasurement();
+      }
+
+      if (
+        measurement.page !== page ||
+        measurement.viewport.name !== viewport.name ||
+        measurement.viewport.width !== viewport.width ||
+        measurement.viewport.height !== viewport.height
+      ) {
+        throwInvalidMeasurement();
+      }
+    }
+  }
+};
+
+const evaluateOverflowCheck = ({
+  durationMs,
+  measurements,
+  target,
+}: EvaluateOverflowCheckOptions): OverflowCheckReport => {
+  validateMeasurementMatrix(target, measurements);
+  const results = measurements.map(createOverflowMeasurement);
+  const failed = results.filter((result) => result.status === "fail").length;
+  const maximumOverflowPx = Math.max(
+    ...results.map((result) => result.overflowPx)
+  );
+  const status = failed > 0 ? ("fail" as const) : ("pass" as const);
+
+  const parsedReport = OverflowCheckReportSchema.safeParse({
+    durationMs,
+    engineVersion: OVERFLOW_ENGINE_VERSION,
+    kind: OVERFLOW_CHECK_KIND,
+    remediation: status === "fail" ? OVERFLOW_REMEDIATION : null,
+    results,
+    schemaVersion: OVERFLOW_CHECK_SCHEMA_VERSION,
+    severity: OVERFLOW_CHECK_SEVERITY,
+    status,
+    summary: {
+      failed,
+      maximumOverflowPx,
+      measurements: results.length,
+    },
+    target,
+    viewports: OVERFLOW_VIEWPORTS,
+  });
+
+  if (!parsedReport.success) {
+    return throwInvalidMeasurement();
+  }
+
+  return parsedReport.data;
+};
+
+export type { EvaluateOverflowCheckOptions };
+export {
+  createOverflowMeasurement,
+  evaluateOverflowCheck,
+  normalizeOverflowCulprits,
+  sanitizeDescriptor,
+};

--- a/packages/cli/src/overflow-check/options.ts
+++ b/packages/cli/src/overflow-check/options.ts
@@ -1,0 +1,166 @@
+import {
+  MAX_OVERFLOW_PAGES,
+  MAX_OVERFLOW_REPORT_PATH_LENGTH,
+  MAX_OVERFLOW_URL_LENGTH,
+} from "./contracts";
+import { OverflowCheckError } from "./error";
+
+const ABSOLUTE_URL_PATTERN = /^[a-z][a-z\d+.-]*:/i;
+
+interface ResolveOverflowCheckTargetOptions {
+  routes?: string[];
+  target: string;
+}
+
+interface ResolvedOverflowPage {
+  displayPath: string;
+  requestedUrl: string;
+}
+
+interface ResolvedOverflowCheckTarget {
+  origin: string;
+  pages: ResolvedOverflowPage[];
+}
+
+const invalidArguments = (message: string): never => {
+  throw new OverflowCheckError("INVALID_ARGUMENTS", message);
+};
+
+const hasUnsafeInput = (value: string): boolean =>
+  Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return (
+      codePoint !== undefined &&
+      (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f))
+    );
+  });
+
+const ensureSafeLength = (
+  value: string,
+  label: string,
+  maximumLength = MAX_OVERFLOW_URL_LENGTH
+): void => {
+  if (value.length > maximumLength) {
+    invalidArguments(`${label} must be at most ${maximumLength} characters.`);
+  }
+
+  if (hasUnsafeInput(value)) {
+    invalidArguments(`${label} cannot contain control characters.`);
+  }
+};
+
+const parseTargetUrl = (value: string): URL => {
+  ensureSafeLength(value, "The overflow target URL");
+  const target = value.trim();
+
+  let url: URL;
+  try {
+    url = new URL(target);
+  } catch {
+    return invalidArguments(
+      "The overflow target must be an absolute HTTP or HTTPS URL."
+    );
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    invalidArguments(
+      "The overflow target must be an absolute HTTP or HTTPS URL."
+    );
+  }
+
+  if (url.username !== "" || url.password !== "") {
+    invalidArguments("The overflow target URL cannot include credentials.");
+  }
+
+  ensureSafeLength(url.href, "The overflow target URL");
+  return url;
+};
+
+const toOverflowDisplayPath = (url: URL): string => {
+  const queryMarker = url.search === "" ? "" : "?[redacted]";
+  const hashMarker = url.hash === "" ? "" : "#[redacted]";
+  const suffix = `${queryMarker}${hashMarker}`;
+  return `${url.pathname.slice(0, MAX_OVERFLOW_REPORT_PATH_LENGTH - suffix.length)}${suffix}`;
+};
+
+const parseRouteUrl = (value: string, origin: string): URL => {
+  ensureSafeLength(value, "Each overflow route");
+  const route = value.trim();
+  if (route === "") {
+    return invalidArguments("Overflow routes cannot be empty.");
+  }
+
+  if (
+    ABSOLUTE_URL_PATTERN.test(route) ||
+    !route.startsWith("/") ||
+    route.startsWith("//") ||
+    route.includes("\\") ||
+    route.includes("?") ||
+    route.includes("#")
+  ) {
+    return invalidArguments(
+      "Overflow routes must start with one slash and cannot contain a query, hash, or backslash."
+    );
+  }
+
+  let url: URL;
+  try {
+    url = new URL(route, `${origin}/`);
+  } catch {
+    return invalidArguments(
+      "Each overflow route must be a valid relative URL."
+    );
+  }
+
+  if (url.origin !== origin) {
+    return invalidArguments(
+      "Overflow routes must be same-origin relative paths."
+    );
+  }
+
+  ensureSafeLength(url.href, "Each overflow route");
+  return url;
+};
+
+const resolveOverflowCheckTarget = ({
+  routes = [],
+  target,
+}: ResolveOverflowCheckTargetOptions): ResolvedOverflowCheckTarget => {
+  const targetUrl = parseTargetUrl(target);
+  const uniqueUrls = new Map<string, URL>([[targetUrl.href, targetUrl]]);
+
+  for (const route of routes) {
+    const url = parseRouteUrl(route, targetUrl.origin);
+    uniqueUrls.set(url.href, url);
+
+    if (uniqueUrls.size > MAX_OVERFLOW_PAGES) {
+      return invalidArguments(
+        `Overflow checks support at most ${MAX_OVERFLOW_PAGES} unique pages.`
+      );
+    }
+  }
+
+  const pages = [...uniqueUrls.values()].map((url) => ({
+    displayPath: toOverflowDisplayPath(url),
+    requestedUrl: url.href,
+  }));
+  if (
+    new Set(pages.map(({ displayPath }) => displayPath)).size !== pages.length
+  ) {
+    return invalidArguments(
+      "Overflow page paths must remain unique within the report length limit."
+    );
+  }
+
+  return {
+    origin: targetUrl.origin,
+    pages,
+  };
+};
+
+export type {
+  ResolvedOverflowCheckTarget,
+  ResolvedOverflowPage,
+  ResolveOverflowCheckTargetOptions,
+};
+export { resolveOverflowCheckTarget, toOverflowDisplayPath };

--- a/packages/cli/src/overflow-check/render-human.ts
+++ b/packages/cli/src/overflow-check/render-human.ts
@@ -1,0 +1,101 @@
+import picocolors from "picocolors";
+import { sanitizeTerminalText } from "../render-human";
+import type { TerminalCapabilities } from "../terminal-capabilities";
+import type {
+  OverflowCheckReport,
+  OverflowMeasurement,
+  OverflowViewport,
+} from "./contracts";
+
+interface RenderOverflowCheckReportOptions {
+  terminal: TerminalCapabilities;
+}
+
+const renderViewport = (
+  viewport: OverflowViewport,
+  terminal: TerminalCapabilities
+): string => {
+  const separator = terminal.unicode ? "×" : "x";
+  return `${viewport.name} (${viewport.width}${separator}${viewport.height})`;
+};
+
+const getOverflowReason = (measurement: OverflowMeasurement): string => {
+  if (!measurement.forcedScrollbar) {
+    return `${measurement.overflowPx}px overflow`;
+  }
+
+  if (measurement.overflowPx > 0) {
+    return `${measurement.overflowPx}px overflow; root scrollbar forced`;
+  }
+
+  return "root scrollbar forced";
+};
+
+const renderFailure = (
+  measurement: OverflowMeasurement,
+  terminal: TerminalCapabilities
+): string[] => {
+  const separator = terminal.unicode ? "×" : "x";
+  const divider = terminal.unicode ? "—" : "-";
+  const overflowReason = getOverflowReason(measurement);
+  const lines = [
+    `  ${sanitizeTerminalText(measurement.page)} ${divider} ${measurement.viewport.name} ${measurement.viewport.width}${separator}${measurement.viewport.height}`,
+    `    ${measurement.scrollWidth}px document / ${measurement.clientWidth}px viewport (${overflowReason})`,
+  ];
+
+  for (const culprit of measurement.culprits) {
+    lines.push(
+      `    Likely culprit: ${sanitizeTerminalText(culprit.descriptor)} (${culprit.overflowPx}px)`
+    );
+  }
+
+  if (measurement.omittedCulprits > 0) {
+    lines.push(`    ${measurement.omittedCulprits} more culprits omitted`);
+  }
+
+  return lines;
+};
+
+const renderOverflowCheckReport = (
+  report: OverflowCheckReport,
+  options: RenderOverflowCheckReportOptions
+): string => {
+  const colors = picocolors.createColors(options.terminal.color);
+  const status =
+    report.status === "pass"
+      ? colors.green(colors.bold("PASS"))
+      : colors.red(colors.bold("CRITICAL FAIL"));
+  const lines = [
+    colors.bold("shadscan overflow check"),
+    "",
+    status,
+    `Target: ${sanitizeTerminalText(report.target.origin)}`,
+    `Viewports: ${report.viewports
+      .map((viewport) => renderViewport(viewport, options.terminal))
+      .join(", ")}`,
+    `Pages: ${report.target.pages.map(sanitizeTerminalText).join(", ")}`,
+  ];
+
+  if (report.status === "pass") {
+    lines.push(
+      "",
+      `No horizontal overflow detected across ${report.summary.measurements} measurements.`
+    );
+  } else {
+    lines.push("", "Failed measurements:");
+    for (const measurement of report.results) {
+      if (measurement.status === "fail") {
+        lines.push(...renderFailure(measurement, options.terminal));
+      }
+    }
+    lines.push(
+      "",
+      `Remediation: ${sanitizeTerminalText(report.remediation ?? "")}`
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+};
+
+export type { RenderOverflowCheckReportOptions };
+export { renderOverflowCheckReport };

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -10,11 +10,13 @@ import {
   createProgram,
   resolveProjectPath,
   runCli,
+  runOverflowCheckAction,
   scoreFailsThreshold,
 } from "../src/cli";
 import { normalizeCliFailure } from "../src/cli-error";
 import { ProjectDiscoveryError } from "../src/discovery";
 import { resolveOutputFormat, wantsJsonOutput } from "../src/output-format";
+import { OverflowCheckError } from "../src/overflow-check/error";
 import { createRuleFixture } from "./rule-fixture";
 import {
   cleanupWorkspaceFixtures,
@@ -137,6 +139,7 @@ describe("CLI contract", () => {
 
     expect(program.helpInformation()).toContain("--apply");
     expect(program.helpInformation()).toContain("--agent <agent>");
+    expect(program.helpInformation()).toContain("--check-overflow <url>");
     expect(program.helpInformation()).toContain("--no-interactive");
     expect(program.commands.map((command) => command.name())).toContain(
       "setup"
@@ -169,6 +172,133 @@ describe("CLI contract", () => {
     } finally {
       await fixture.cleanup();
     }
+  });
+
+  it("renders focused overflow JSON and exits on a completed finding", async () => {
+    let stdout = "";
+    const write = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdout += String(chunk);
+        return true;
+      });
+    const runBrowserCheck = vi.fn(async () => ({
+      browser: { name: "chromium", version: "123" },
+      durationMs: 12,
+      measurements: [
+        {
+          clientWidth: 320,
+          culprits: [
+            {
+              depth: 2,
+              descriptor: '[data-slot="wide"]',
+              left: 0,
+              order: 1,
+              overflowPx: 1,
+              right: 321,
+            },
+          ],
+          finalPath: "/",
+          forcedScrollbar: false,
+          httpStatus: 200,
+          page: "/",
+          scrollWidth: 321,
+          viewport: { height: 820, name: "mobile", width: 320 } as const,
+        },
+        {
+          clientWidth: 1440,
+          finalPath: "/",
+          forcedScrollbar: false,
+          httpStatus: 200,
+          page: "/",
+          scrollWidth: 1440,
+          viewport: {
+            height: 1000,
+            name: "desktop",
+            width: 1440,
+          } as const,
+        },
+      ],
+    }));
+
+    try {
+      await runOverflowCheckAction(
+        {
+          outputFormat: "json",
+          target: "http://127.0.0.1:3000",
+        },
+        { runBrowserCheck }
+      );
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(runBrowserCheck).toHaveBeenCalledOnce();
+    expect(JSON.parse(stdout)).toMatchObject({
+      kind: "overflow-check",
+      schemaVersion: 1,
+      status: "fail",
+      summary: { failed: 1, maximumOverflowPx: 1, measurements: 2 },
+    });
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("rejects focused overflow-only options during static scans", async () => {
+    await expect(captureOutput(["--route", "/dashboard"])).rejects.toThrow(
+      "--route requires --check-overflow."
+    );
+    await expect(
+      captureOutput(["--browser-executable", "/tmp/chromium"])
+    ).rejects.toThrow("--browser-executable requires --check-overflow.");
+  });
+
+  it("rejects static scan controls in focused overflow mode before launch", async () => {
+    const conflicts = [
+      { arguments: ["--category", "forms"], option: "--category" },
+      { arguments: ["--fail-under", "90"], option: "--fail-under" },
+      { arguments: ["--apply"], option: "--apply" },
+      { arguments: ["--agent", "codex"], option: "--agent" },
+      { arguments: ["--format", "prompt"], option: "--prompt" },
+      { arguments: ["--list-projects"], option: "--list-projects" },
+      { arguments: ["--project", "apps/web"], option: "--project" },
+      { arguments: ["--roast"], option: "--roast" },
+    ];
+
+    for (const conflict of conflicts) {
+      await expect(
+        captureOutput([
+          "--check-overflow",
+          "http://127.0.0.1:3000",
+          ...conflict.arguments,
+        ])
+      ).rejects.toThrow(
+        `--check-overflow cannot be used with ${conflict.option}.`
+      );
+    }
+  });
+
+  it("does not let focused overflow flags leak into subcommands", async () => {
+    await expect(
+      captureOutput([
+        "--check-overflow",
+        "http://127.0.0.1:3000",
+        "setup",
+        "--pre-commit",
+        "--dry-run",
+      ])
+    ).rejects.toThrow(
+      "--check-overflow and its related options cannot be used with subcommands."
+    );
+  });
+
+  it("rejects a project path in focused overflow mode", async () => {
+    await expect(
+      captureOutput([
+        "some-project",
+        "--check-overflow",
+        "http://127.0.0.1:3000",
+      ])
+    ).rejects.toThrow("--check-overflow does not accept a project path.");
   });
 
   it("renders a deterministic score bar when stdout is not a TTY", async () => {
@@ -624,6 +754,17 @@ describe("CLI contract", () => {
     expect(normalizeCliFailure(new Error("private runtime detail"))).toEqual({
       code: "AUDIT_FAILED",
       message: "shadscan could not complete the audit.",
+    });
+    expect(
+      normalizeCliFailure(
+        new OverflowCheckError(
+          "OVERFLOW_BROWSER_UNAVAILABLE",
+          "Install Chromium."
+        )
+      )
+    ).toEqual({
+      code: "OVERFLOW_BROWSER_UNAVAILABLE",
+      message: "Install Chromium.",
     });
   });
 });

--- a/packages/cli/test/overflow-browser.test.ts
+++ b/packages/cli/test/overflow-browser.test.ts
@@ -1,0 +1,265 @@
+import type {
+  Browser,
+  BrowserContext,
+  BrowserContextOptions,
+  BrowserType,
+  Page,
+  Response,
+  Route,
+} from "playwright-core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type OverflowBrowserDependencies,
+  runOverflowBrowserCheck,
+  sanitizeReportPath,
+} from "../src/overflow-check/browser";
+
+const TARGET_ORIGIN = "http://127.0.0.1:4173";
+
+interface BrowserFixture {
+  abortRequest: ReturnType<typeof vi.fn>;
+  browser: Browser;
+  closeBrowser: ReturnType<typeof vi.fn>;
+  closeContexts: ReturnType<typeof vi.fn>[];
+  dependencies: OverflowBrowserDependencies;
+  launch: ReturnType<typeof vi.fn>;
+  newContext: ReturnType<typeof vi.fn>;
+}
+
+const createBrowserFixture = ({
+  crossOriginNavigation = false,
+  failManagedLaunch = false,
+  failMeasurement = false,
+}: {
+  crossOriginNavigation?: boolean;
+  failManagedLaunch?: boolean;
+  failMeasurement?: boolean;
+} = {}): BrowserFixture => {
+  const closeBrowser = vi.fn(() => Promise.resolve(undefined));
+  const closeContexts: ReturnType<typeof vi.fn>[] = [];
+  const abortRequest = vi.fn(() => Promise.resolve(undefined));
+  const response = {
+    headers: () => ({ "content-type": "text/html; charset=utf-8" }),
+    request: () => ({
+      redirectedFrom: () => null,
+      url: () => `${TARGET_ORIGIN}/fits?token=private#account`,
+    }),
+    status: () => 200,
+  } as unknown as Response;
+
+  const newContext = vi.fn((options: BrowserContextOptions) => {
+    const clientWidth = options.viewport?.width ?? 0;
+    const closeContext = vi.fn(() => Promise.resolve(undefined));
+    const mainFrame = {};
+    let routeHandler: ((route: Route) => Promise<unknown>) | undefined;
+    closeContexts.push(closeContext);
+    const page = {
+      evaluate: vi.fn((pageFunction: unknown) => {
+        if (typeof pageFunction === "string") {
+          return Promise.resolve(undefined);
+        }
+
+        const functionName =
+          typeof pageFunction === "function" ? pageFunction.name : "";
+        if (functionName === "readDocumentWidthVector") {
+          return Promise.resolve([clientWidth, clientWidth, clientWidth]);
+        }
+        if (functionName === "waitForTwoAnimationFrames") {
+          return Promise.resolve(undefined);
+        }
+        if (failMeasurement) {
+          return Promise.reject(new Error("private browser detail"));
+        }
+
+        return Promise.resolve({
+          clientWidth,
+          culprits: [],
+          forcedScrollbar: false,
+          omittedCulprits: 0,
+          scrollWidth: clientWidth,
+        });
+      }),
+      goto: vi.fn(async () => {
+        if (crossOriginNavigation && routeHandler) {
+          await routeHandler({
+            abort: abortRequest,
+            continue: vi.fn(() => Promise.resolve(undefined)),
+            request: () => ({
+              frame: () => mainFrame,
+              isNavigationRequest: () => true,
+              url: () => "https://external.example/private",
+            }),
+          } as unknown as Route);
+        }
+        return response;
+      }),
+      mainFrame: () => mainFrame,
+      on: vi.fn(),
+      route: vi.fn(
+        (_pattern: string, handler: (route: Route) => Promise<unknown>) => {
+          routeHandler = handler;
+          return Promise.resolve(undefined);
+        }
+      ),
+      url: () => `${TARGET_ORIGIN}/fits?token=private#account`,
+    } as unknown as Page;
+    const browserContext = {
+      close: closeContext,
+      newPage: vi.fn(() => Promise.resolve(page)),
+      on: vi.fn(),
+    } as unknown as BrowserContext;
+    return Promise.resolve(browserContext);
+  });
+  const browser = {
+    close: closeBrowser,
+    newContext,
+    version: () => "123.0.0.0",
+  } as unknown as Browser;
+  const launch = vi.fn(
+    (options: { channel?: string; executablePath?: string }) => {
+      if (failManagedLaunch && !options.channel && !options.executablePath) {
+        return Promise.reject(new Error("managed browser missing"));
+      }
+      return Promise.resolve(browser);
+    }
+  );
+  const chromium = { launch } as unknown as BrowserType;
+
+  return {
+    abortRequest,
+    browser,
+    closeBrowser,
+    closeContexts,
+    dependencies: {
+      loadPlaywright: () => Promise.resolve({ chromium }),
+      now: () => 1000,
+      wait: () => Promise.resolve(undefined),
+    },
+    launch,
+    newContext,
+  };
+};
+
+describe("runOverflowBrowserCheck", () => {
+  it("falls back to stable Chrome and cleans every isolated context", async () => {
+    const fixture = createBrowserFixture({ failManagedLaunch: true });
+
+    const result = await runOverflowBrowserCheck(
+      {
+        origin: TARGET_ORIGIN,
+        pages: [
+          {
+            displayPath: "/fits?[redacted]#[redacted]",
+            requestedUrl: `${TARGET_ORIGIN}/fits?token=private#account`,
+          },
+        ],
+      },
+      fixture.dependencies
+    );
+
+    expect(fixture.launch).toHaveBeenCalledTimes(2);
+    expect(fixture.launch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ channel: "chrome", headless: true })
+    );
+    expect(result.browser).toEqual({ name: "chrome", version: "123.0.0.0" });
+    expect(
+      result.measurements.map((measurement) => measurement.viewport)
+    ).toEqual([
+      { height: 820, name: "mobile", width: 320 },
+      { height: 1000, name: "desktop", width: 1440 },
+    ]);
+    expect(result.measurements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          finalPath: "/fits",
+          page: "/fits?[redacted]#[redacted]",
+        }),
+      ])
+    );
+    expect(fixture.newContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        acceptDownloads: false,
+        colorScheme: "light",
+        deviceScaleFactor: 1,
+        serviceWorkers: "block",
+      })
+    );
+    expect(fixture.closeContexts).toHaveLength(2);
+    expect(
+      fixture.closeContexts.every((close) => close.mock.calls.length === 1)
+    ).toBe(true);
+    expect(fixture.closeBrowser).toHaveBeenCalledOnce();
+  });
+
+  it("uses only the explicit executable when one is provided", async () => {
+    const fixture = createBrowserFixture();
+
+    await runOverflowBrowserCheck(
+      {
+        browserExecutable: "/opt/chromium",
+        origin: TARGET_ORIGIN,
+        pages: [{ displayPath: "/", requestedUrl: `${TARGET_ORIGIN}/` }],
+      },
+      fixture.dependencies
+    );
+
+    expect(fixture.launch).toHaveBeenCalledOnce();
+    expect(fixture.launch).toHaveBeenCalledWith(
+      expect.objectContaining({ executablePath: "/opt/chromium" })
+    );
+  });
+
+  it("normalizes unexpected page failures and still closes the browser", async () => {
+    const fixture = createBrowserFixture({ failMeasurement: true });
+
+    await expect(
+      runOverflowBrowserCheck(
+        {
+          origin: TARGET_ORIGIN,
+          pages: [{ displayPath: "/", requestedUrl: `${TARGET_ORIGIN}/` }],
+        },
+        fixture.dependencies
+      )
+    ).rejects.toMatchObject({
+      code: "OVERFLOW_CHECK_FAILED",
+      message: "The browser could not complete the horizontal overflow check.",
+    });
+    expect(fixture.closeBrowser).toHaveBeenCalledOnce();
+    expect(fixture.closeContexts).toHaveLength(2);
+    expect(
+      fixture.closeContexts.every((close) => close.mock.calls.length === 1)
+    ).toBe(true);
+  });
+
+  it("blocks cross-origin top-level navigation before measurement", async () => {
+    const fixture = createBrowserFixture({ crossOriginNavigation: true });
+
+    await expect(
+      runOverflowBrowserCheck(
+        {
+          origin: TARGET_ORIGIN,
+          pages: [{ displayPath: "/", requestedUrl: `${TARGET_ORIGIN}/` }],
+        },
+        fixture.dependencies
+      )
+    ).rejects.toMatchObject({
+      code: "OVERFLOW_TARGET_UNAVAILABLE",
+      message: "The target page / attempted a cross-origin navigation.",
+    });
+    expect(fixture.abortRequest).toHaveBeenCalledTimes(2);
+    expect(fixture.closeBrowser).toHaveBeenCalledOnce();
+  });
+});
+
+describe("sanitizeReportPath", () => {
+  it("removes query and fragment secrets", () => {
+    expect(
+      sanitizeReportPath(`${TARGET_ORIGIN}/settings?token=private#account`)
+    ).toBe("/settings");
+  });
+
+  it("uses a safe fallback for malformed browser URLs", () => {
+    expect(sanitizeReportPath("not a URL")).toBe("/");
+  });
+});

--- a/packages/cli/test/overflow-check-core.test.ts
+++ b/packages/cli/test/overflow-check-core.test.ts
@@ -1,0 +1,359 @@
+import { describe, expect, it } from "vitest";
+import type {
+  OverflowCheckReport,
+  OverflowCulpritCandidate,
+  OverflowMeasurementInput,
+} from "../src/overflow-check/contracts";
+import {
+  OVERFLOW_VIEWPORTS,
+  OverflowCheckReportSchema,
+} from "../src/overflow-check/contracts";
+import { OverflowCheckError } from "../src/overflow-check/error";
+import {
+  createOverflowMeasurement,
+  evaluateOverflowCheck,
+} from "../src/overflow-check/evaluate";
+import { resolveOverflowCheckTarget } from "../src/overflow-check/options";
+import { renderOverflowCheckReport } from "../src/overflow-check/render-human";
+import type { TerminalCapabilities } from "../src/terminal-capabilities";
+
+const AUDIT_LANGUAGE_PATTERN = /score|grade|rule/iu;
+
+const PLAIN_TERMINAL = {
+  color: false,
+  columns: null,
+  unicode: false,
+} as const satisfies TerminalCapabilities;
+
+const createMeasurement = ({
+  clientWidth = 320,
+  culprits,
+  forcedScrollbar = false,
+  page = "/",
+  scrollWidth = clientWidth,
+  viewport = OVERFLOW_VIEWPORTS[0],
+}: Partial<OverflowMeasurementInput> = {}): OverflowMeasurementInput => ({
+  clientWidth,
+  culprits,
+  finalPath: page,
+  forcedScrollbar,
+  httpStatus: 200,
+  page,
+  scrollWidth,
+  viewport,
+});
+
+const createMeasurementMatrix = (
+  page = "/",
+  overrides: Partial<OverflowMeasurementInput> = {}
+): OverflowMeasurementInput[] =>
+  OVERFLOW_VIEWPORTS.map((viewport) =>
+    createMeasurement({
+      clientWidth: viewport.width,
+      page,
+      scrollWidth: viewport.width,
+      viewport,
+      ...overrides,
+    })
+  );
+
+const evaluate = (
+  measurements: OverflowMeasurementInput[] = createMeasurementMatrix()
+): OverflowCheckReport =>
+  evaluateOverflowCheck({
+    durationMs: 42,
+    measurements,
+    target: { origin: "https://example.com", pages: ["/"] },
+  });
+
+describe("resolveOverflowCheckTarget", () => {
+  it("preserves the exact navigable target while redacting report secrets", () => {
+    const target = resolveOverflowCheckTarget({
+      routes: ["/dashboard", "/dashboard", "/settings/profile"],
+      target: "https://example.com/start?token=secret#private",
+    });
+
+    expect(target).toEqual({
+      origin: "https://example.com",
+      pages: [
+        {
+          displayPath: "/start?[redacted]#[redacted]",
+          requestedUrl: "https://example.com/start?token=secret#private",
+        },
+        {
+          displayPath: "/dashboard",
+          requestedUrl: "https://example.com/dashboard",
+        },
+        {
+          displayPath: "/settings/profile",
+          requestedUrl: "https://example.com/settings/profile",
+        },
+      ],
+    });
+    expect(
+      JSON.stringify(target.pages.map(({ displayPath }) => displayPath))
+    ).not.toContain("secret");
+  });
+
+  it.each([
+    "ftp://example.com",
+    "https://user:password@example.com",
+    "https://example.com/\n",
+    "not a URL",
+  ])("rejects unsafe targets: %s", (target) => {
+    expect(() => resolveOverflowCheckTarget({ target })).toThrow(
+      OverflowCheckError
+    );
+  });
+
+  it.each([
+    "dashboard",
+    "//example.com/dashboard",
+    "/dashboard?token=secret",
+    "/dashboard#section",
+    "/dashboard\\nested",
+    "https://example.com/dashboard",
+  ])("rejects a non-path route: %s", (route) => {
+    expect(() =>
+      resolveOverflowCheckTarget({
+        routes: [route],
+        target: "https://example.com",
+      })
+    ).toThrowError(
+      "Overflow routes must start with one slash and cannot contain a query, hash, or backslash."
+    );
+  });
+
+  it("rejects route controls before trimming input", () => {
+    expect(() =>
+      resolveOverflowCheckTarget({
+        routes: ["/dashboard\n"],
+        target: "https://example.com",
+      })
+    ).toThrowError("Each overflow route cannot contain control characters.");
+  });
+
+  it("caps the unique page set at ten", () => {
+    expect(() =>
+      resolveOverflowCheckTarget({
+        routes: Array.from({ length: 10 }, (_, index) => `/page-${index}`),
+        target: "https://example.com",
+      })
+    ).toThrowError("Overflow checks support at most 10 unique pages.");
+  });
+
+  it("rejects long routes that collide after safe report truncation", () => {
+    const sharedPrefix = `/${"a".repeat(1100)}`;
+
+    expect(() =>
+      resolveOverflowCheckTarget({
+        routes: [`${sharedPrefix}x`, `${sharedPrefix}y`],
+        target: "https://example.com",
+      })
+    ).toThrowError(
+      "Overflow page paths must remain unique within the report length limit."
+    );
+  });
+});
+
+describe("overflow report evaluation", () => {
+  it("passes at zero pixels and fails at exactly one pixel", () => {
+    expect(createOverflowMeasurement(createMeasurement()).status).toBe("pass");
+    expect(
+      createOverflowMeasurement(
+        createMeasurement({ clientWidth: 320, scrollWidth: 321 })
+      )
+    ).toMatchObject({ overflowPx: 1, status: "fail" });
+  });
+
+  it("fails a forced root scrollbar with no width delta", () => {
+    expect(
+      createOverflowMeasurement(createMeasurement({ forcedScrollbar: true }))
+    ).toMatchObject({
+      culprits: [],
+      forcedScrollbar: true,
+      overflowPx: 0,
+      status: "fail",
+    });
+  });
+
+  it("reports browser-clamped extremely wide documents as findings", () => {
+    expect(
+      createOverflowMeasurement(
+        createMeasurement({ clientWidth: 320, scrollWidth: 20_000_000 })
+      )
+    ).toMatchObject({ overflowPx: 19_999_680, status: "fail" });
+  });
+
+  it("sorts, sanitizes, and caps culprit evidence deterministically", () => {
+    const candidates: OverflowCulpritCandidate[] = [
+      {
+        depth: 1,
+        descriptor: "#earlier",
+        left: 0,
+        order: 0,
+        overflowPx: 5,
+        right: 325,
+      },
+      {
+        depth: 3,
+        descriptor: "div\u001b[31m\nwide",
+        left: 0,
+        order: 2,
+        overflowPx: 5,
+        right: 325,
+      },
+      {
+        depth: 2,
+        descriptor: "#largest",
+        left: 0,
+        order: 3,
+        overflowPx: 12,
+        right: 332,
+      },
+      {
+        depth: 0,
+        descriptor: "#omitted",
+        left: 0,
+        order: 4,
+        overflowPx: 1,
+        right: 321,
+      },
+    ];
+    const measurement = createOverflowMeasurement(
+      createMeasurement({
+        clientWidth: 320,
+        culprits: candidates,
+        scrollWidth: 332,
+      })
+    );
+
+    expect(measurement.culprits.map(({ descriptor }) => descriptor)).toEqual([
+      "#largest",
+      "div [31m wide",
+      "#earlier",
+    ]);
+    expect(measurement.omittedCulprits).toBe(1);
+    expect(JSON.stringify(measurement)).not.toContain("\u001b");
+  });
+
+  it("requires one mobile and one desktop result for every page", () => {
+    expect(() => evaluate(createMeasurementMatrix().slice(0, 1))).toThrowError(
+      "The browser returned an invalid horizontal overflow measurement."
+    );
+    expect(() =>
+      evaluate([
+        createMeasurement({ viewport: OVERFLOW_VIEWPORTS[1] }),
+        createMeasurement({ viewport: OVERFLOW_VIEWPORTS[0] }),
+      ])
+    ).toThrowError(
+      "The browser returned an invalid horizontal overflow measurement."
+    );
+  });
+
+  it("validates report summary and status invariants", () => {
+    const report = evaluate(
+      createMeasurementMatrix("/", { scrollWidth: 1441 })
+    );
+
+    expect(report.status).toBe("fail");
+    expect(report.summary).toEqual({
+      failed: 2,
+      maximumOverflowPx: 1121,
+      measurements: 2,
+    });
+    expect(
+      OverflowCheckReportSchema.safeParse({
+        ...report,
+        summary: { ...report.summary, failed: 0 },
+      }).success
+    ).toBe(false);
+  });
+
+  it("keeps a maximum-sized report below 100 KB", () => {
+    const pages = Array.from({ length: 10 }, (_, index) => {
+      const suffix = String(index);
+      return `/${"p".repeat(1023 - suffix.length)}${suffix}`;
+    });
+    const culprits: OverflowCulpritCandidate[] = Array.from(
+      { length: 3 },
+      (_, index) => ({
+        depth: index,
+        descriptor: "c".repeat(160),
+        left: 0,
+        order: index,
+        overflowPx: 1,
+        right: 321,
+      })
+    );
+    const measurements = pages.flatMap((page) =>
+      OVERFLOW_VIEWPORTS.map((viewport) =>
+        createMeasurement({
+          clientWidth: viewport.width,
+          culprits,
+          page,
+          scrollWidth: viewport.width + 1,
+          viewport,
+        })
+      )
+    );
+    const report = evaluateOverflowCheck({
+      durationMs: 60_000,
+      measurements,
+      target: { origin: "https://example.com", pages },
+    });
+
+    expect(
+      Buffer.byteLength(JSON.stringify(report, null, 2), "utf8")
+    ).toBeLessThan(100_000);
+  });
+});
+
+describe("renderOverflowCheckReport", () => {
+  it("renders a standalone critical failure without audit score language", () => {
+    const culprit: OverflowCulpritCandidate = {
+      depth: 1,
+      descriptor: "#wide\u001b[31m",
+      left: 0,
+      order: 0,
+      overflowPx: 1,
+      right: 321,
+    };
+    const report = evaluate([
+      createMeasurement({
+        clientWidth: 320,
+        culprits: [culprit],
+        scrollWidth: 321,
+        viewport: OVERFLOW_VIEWPORTS[0],
+      }),
+      createMeasurement({
+        clientWidth: 1440,
+        scrollWidth: 1440,
+        viewport: OVERFLOW_VIEWPORTS[1],
+      }),
+    ]);
+    const output = renderOverflowCheckReport(report, {
+      terminal: PLAIN_TERMINAL,
+    });
+
+    expect(output).toContain("shadscan overflow check");
+    expect(output).toContain("CRITICAL FAIL");
+    expect(output).toContain("mobile 320x820");
+    expect(output).toContain("Likely culprit: #wide [31m (1px)");
+    expect(output).toContain("min-width: 0");
+    expect(output).not.toMatch(AUDIT_LANGUAGE_PATTERN);
+    expect(output).not.toContain("\u001b");
+  });
+
+  it("renders a concise pass", () => {
+    const output = renderOverflowCheckReport(evaluate(), {
+      terminal: PLAIN_TERMINAL,
+    });
+
+    expect(output).toContain("PASS");
+    expect(output).toContain(
+      "No horizontal overflow detected across 2 measurements."
+    );
+    expect(output).not.toContain("Remediation:");
+  });
+});

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -21,6 +21,7 @@ export default defineConfig([
       index: "src/index.ts",
     },
     esbuildOptions: configureEsbuild,
+    external: ["playwright-core"],
     format: ["esm"],
     // The MCP SDK (and the validator family its server core imports) is a
     // devDependency bundled into dist, mirroring commander: users install
@@ -49,6 +50,7 @@ export default defineConfig([
       index: "src/index.ts",
     },
     esbuildOptions: configureEsbuild,
+    external: ["playwright-core"],
     format: ["esm"],
     noExternal: [/.*/],
     outDir: "../../.shadscan-runtime",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       picocolors:
         specifier: 1.1.1
         version: 1.1.1
+      playwright-core:
+        specifier: 1.61.1
+        version: 1.61.1
       tinyglobby:
         specifier: 0.2.15
         version: 0.2.15

--- a/scripts/verify-production-trace.mjs
+++ b/scripts/verify-production-trace.mjs
@@ -330,6 +330,15 @@ const toProjectPath = (tracePath, tracedFile) => {
   return relativePath.split(path.sep).join("/");
 };
 
+const hostedScannerRuntime = await readFile(SHADSCAN_CLI_RUNTIME_PATH, "utf8");
+const PLAYWRIGHT_RUNTIME_IMPORT_PATTERN =
+  /(?:\b(?:import|require)\s*\(\s*["']playwright-core(?:\/[^"']*)?["']|\bimport\s*["']playwright-core(?:\/[^"']*)?["']|\b(?:import|export)\s+[^;\n]*?\bfrom\s*["']playwright-core(?:\/[^"']*)?["'])/;
+if (PLAYWRIGHT_RUNTIME_IMPORT_PATTERN.test(hostedScannerRuntime)) {
+  throw new Error(
+    "The local-only overflow browser dependency leaked into the hosted scanner runtime."
+  );
+}
+
 for (const { requiredRuntimeFiles, tracePath } of TRACE_TARGETS) {
   const trace = JSON.parse(await readFile(tracePath, "utf8"));
   const entryPath = path.resolve(tracePath.replace(/\.nft\.json$/, ""));
@@ -360,10 +369,18 @@ for (const { requiredRuntimeFiles, tracePath } of TRACE_TARGETS) {
     await findMissingNextRuntimeFiles(tracedPaths);
   const scannerDependencySymlinks =
     await findScannerDependencySymlinks(tracedPaths);
+  const playwrightTracePaths = tracedPaths
+    .map(toComparablePath)
+    .filter(
+      (filePath) =>
+        filePath.includes("/node_modules/playwright-core/") ||
+        filePath.includes("/node_modules/.pnpm/playwright-core@")
+    );
 
   if (
     missingRuntimeFiles.length > 0 ||
     missingNextRuntimeFiles.length > 0 ||
+    playwrightTracePaths.length > 0 ||
     scannerDependencySymlinks.length > 0 ||
     unrelatedFiles.length > 0
   ) {
@@ -373,6 +390,9 @@ for (const { requiredRuntimeFiles, tracePath } of TRACE_TARGETS) {
         : null,
       missingNextRuntimeFiles.length > 0
         ? `missing Next runtime: ${missingNextRuntimeFiles.join(", ")}`
+        : null,
+      playwrightTracePaths.length > 0
+        ? `local-only Playwright runtime: ${playwrightTracePaths.join(", ")}`
         : null,
       scannerDependencySymlinks.length > 0
         ? `scanner dependency symlinks: ${scannerDependencySymlinks.join(", ")}`

--- a/test/e2e/docs-page.spec.ts
+++ b/test/e2e/docs-page.spec.ts
@@ -40,7 +40,22 @@ test("documents the CLI before the optional agent workflow", async ({
   await expect(
     page.locator("#options dt").getByText("--agent <agent>", { exact: true })
   ).toBeVisible();
+  await expect(
+    page
+      .locator("#options dt")
+      .getByText("--check-overflow <url>", { exact: true })
+  ).toBeVisible();
   await expect(page.getByText("production-polish")).toBeVisible();
+
+  const overflowCheck = page.locator("#overflow-check");
+  await expect(overflowCheck).toContainText(
+    "--check-overflow http://localhost:3000 --route /dashboard"
+  );
+  await expect(overflowCheck).toContainText("Mobile: 320 × 820");
+  await expect(overflowCheck).toContainText("Desktop: 1440 × 1000");
+  await expect(overflowCheck).toContainText(
+    "standalone rendered check, not another source-audit rule"
+  );
 
   const agentPrompt = page.locator("#agent-prompt");
   await agentPrompt.getByRole("tab", { name: "bun", exact: true }).click();

--- a/test/e2e/metadata.spec.ts
+++ b/test/e2e/metadata.spec.ts
@@ -24,7 +24,7 @@ const PAGE_METADATA = [
   {
     browserTitle: "Shadscan CLI documentation | shadscan",
     description:
-      "Run Shadscan, inspect a progress-bar score, launch a coding agent, enforce score thresholds, and add a safe pre-commit gate.",
+      "Run Shadscan, check rendered horizontal overflow, inspect a progress-bar score, launch a coding agent, and enforce score thresholds.",
     imagePath: "/docs/opengraph-image",
     path: "/docs",
     socialTitle: "Shadscan CLI documentation | shadscan",

--- a/test/e2e/overflow-check.spec.ts
+++ b/test/e2e/overflow-check.spec.ts
@@ -1,0 +1,714 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { chromium, expect, test } from "@playwright/test";
+
+const CLI_ENTRYPOINT = resolve("packages/cli/dist/cli.js");
+const COMMAND_TIMEOUT_MS = 40_000;
+
+interface CliResult {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+}
+
+interface OverflowMeasurement {
+  clientWidth: number;
+  culprits: Array<{
+    descriptor: string;
+  }>;
+  finalPath: string;
+  forcedScrollbar: boolean;
+  httpStatus: number;
+  overflowPx: number;
+  page: string;
+  scrollWidth: number;
+  status: "fail" | "pass";
+  viewport: {
+    height: number;
+    name: "desktop" | "mobile";
+    width: number;
+  };
+}
+
+interface OverflowReport {
+  durationMs: number;
+  kind: "overflow-check";
+  results: OverflowMeasurement[];
+  schemaVersion: 1;
+  severity: "critical";
+  status: "fail" | "pass";
+  summary: {
+    failed: number;
+    maximumOverflowPx: number;
+    measurements: number;
+  };
+}
+
+interface CliProcessError extends Error {
+  code?: number | string | null;
+  killed?: boolean;
+  stderr?: string;
+  stdout?: string;
+}
+
+const fixtureMarkup = (pathname: string): string | null => {
+  const sharedStyles =
+    "html,body{margin:0;min-height:100%;padding:0}*{box-sizing:border-box}";
+
+  if (pathname === "/fits") {
+    return `<style>${sharedStyles}</style><main data-slot="fits">Fits</main>`;
+  }
+
+  if (pathname === "/local-scroller") {
+    return `<style>${sharedStyles}</style><div data-slot="local-scroller" style="max-width:100%;overflow-x:auto"><div style="width:640px">Contained overflow</div></div>`;
+  }
+
+  if (pathname === "/subpixel") {
+    return `<style>${sharedStyles}</style><div data-slot="subpixel" style="width:320.49px">Rounded without a scroll range</div>`;
+  }
+
+  if (pathname === "/vertical-only") {
+    return `<style>${sharedStyles}body{min-height:2000px}</style><main>Vertical scrolling only</main>`;
+  }
+
+  if (pathname === "/delayed-fit") {
+    return `<style>${sharedStyles}</style><div data-slot="delayed-fit" style="width:calc(100vw + 1px)">Settling</div><script>setTimeout(()=>{document.querySelector('[data-slot="delayed-fit"]').style.width='100%'},1000)</script>`;
+  }
+
+  if (pathname === "/delayed-font-ready") {
+    return `<style>${sharedStyles}</style><div data-slot="font-layout" style="width:calc(100vw + 1px)">Loading font layout</div><script>const layout=document.querySelector('[data-slot="font-layout"]');const ready=new Promise((resolve)=>setTimeout(()=>{layout.style.width='100%';resolve()},1400));Object.defineProperty(document,'fonts',{configurable:true,value:{ready}})</script>`;
+  }
+
+  if (pathname === "/unstable-width") {
+    return `<style>${sharedStyles}</style><div data-slot="unstable-width" style="height:1px;width:100vw"></div><script>const unstable=document.querySelector('[data-slot="unstable-width"]');let extraWidth=0;setInterval(()=>{extraWidth+=1;unstable.style.width='calc(100vw + '+extraWidth+'px)'},25)</script>`;
+  }
+
+  if (pathname === "/motion-overflow") {
+    return `<style>${sharedStyles}[data-slot="motion-overflow"]{height:1px;width:calc(100vw + 1px)}@media(prefers-reduced-motion:reduce){[data-slot="motion-overflow"]{width:100%}}</style><div data-slot="motion-overflow"></div>`;
+  }
+
+  if (pathname === "/hash-overflow") {
+    return `<style>${sharedStyles}body{position:relative}[data-slot="normal"]{height:1px;width:100%}#target{height:1px;left:1000px;position:absolute;width:1px}</style><div data-slot="normal"></div><div id="target"></div>`;
+  }
+
+  if (pathname === "/many-culprits") {
+    return `<style>${sharedStyles}.culprit{height:1px;width:calc(100vw + 1px)}</style>${'<div class="culprit"></div>'.repeat(20_000)}`;
+  }
+
+  if (pathname === "/client-redirect") {
+    return `<style>${sharedStyles}</style><main>Redirecting</main><script>setTimeout(()=>location.replace('https://example.invalid/private?token=must-not-leak'),100)</script>`;
+  }
+
+  if (pathname === "/client-404") {
+    return `<style>${sharedStyles}</style><main>Redirecting</main><script>setTimeout(()=>location.replace('/missing'),100)</script>`;
+  }
+
+  if (pathname === "/immediate-404") {
+    return `<style>${sharedStyles}</style><main>Redirecting</main><script>location.replace('/missing')</script>`;
+  }
+
+  if (pathname === "/client-blob") {
+    return `<style>${sharedStyles}</style><main>Redirecting</main><script>const blobUrl=URL.createObjectURL(new Blob(['<!doctype html><title>Blob page</title>'],{type:'text/html'}));setTimeout(()=>location.replace(blobUrl),100)</script>`;
+  }
+
+  if (pathname === "/one-pixel") {
+    return `<style>${sharedStyles}@media(max-width:400px){[data-slot="one-pixel"]{width:321px}}</style><div data-slot="one-pixel">One pixel wider on mobile</div>`;
+  }
+
+  if (pathname === "/forced-scrollbar") {
+    return `<style>${sharedStyles}html{overflow-x:scroll}</style><main>Forced scrollbar</main>`;
+  }
+
+  if (pathname === "/translated") {
+    return `<style>${sharedStyles}</style><div data-slot="translated" style="height:1px;transform:translateX(1px);width:100vw"></div>`;
+  }
+
+  if (pathname === "/absolute") {
+    return `<style>${sharedStyles}body{position:relative}</style><div data-slot="absolute" style="height:1px;left:100%;position:absolute;width:1px"></div>`;
+  }
+
+  if (pathname === "/pseudo") {
+    return `<style>${sharedStyles}body{position:relative}body::after{content:"";height:1px;left:100%;position:absolute;width:1px}</style><main>Pseudo-element overflow</main>`;
+  }
+
+  if (pathname === "/svg") {
+    return `<style>${sharedStyles}svg{display:block;width:100%}@media(min-width:1000px){svg{width:calc(100vw + 1px)}}</style><svg data-slot="wide-svg" height="1"></svg>`;
+  }
+
+  if (pathname === "/rtl-left") {
+    return `<style>${sharedStyles}html{direction:rtl}body{position:relative}</style><div data-slot="rtl-left" style="height:1px;position:absolute;right:100%;width:1px"></div>`;
+  }
+
+  if (pathname === "/root-hidden") {
+    return `<style>${sharedStyles}html{overflow-x:hidden}</style><div data-slot="hidden-overflow" style="height:1px;width:calc(100vw + 1px)"></div>`;
+  }
+
+  if (pathname === "/root-clip") {
+    return `<style>${sharedStyles}html{overflow-x:clip}</style><div data-slot="clipped-overflow" style="height:1px;width:calc(100vw + 1px)"></div>`;
+  }
+
+  if (pathname === "/open-shadow-root") {
+    return `<style>${sharedStyles}</style><div data-slot="shadow-host"></div><script>const host=document.querySelector('[data-slot="shadow-host"]');const shadow=host.attachShadow({mode:'open'});shadow.innerHTML='<div data-slot="shadow-overflow" style="height:1px;width:calc(100vw + 1px)"></div>'</script>`;
+  }
+
+  return null;
+};
+
+const runOverflowCheck = async (arguments_: string[]): Promise<CliResult> => {
+  try {
+    const result = await new Promise<{ stderr: string; stdout: string }>(
+      (resolveResult, rejectResult) => {
+        execFile(
+          process.execPath,
+          [CLI_ENTRYPOINT, ...arguments_],
+          {
+            cwd: emptyWorkingDirectory,
+            encoding: "utf8",
+            env: {
+              ...process.env,
+              CI: "1",
+              FORCE_COLOR: undefined,
+              NO_COLOR: "1",
+              SHADSCAN_INTERACTIVE: "0",
+            },
+            maxBuffer: 1_000_000,
+            timeout: COMMAND_TIMEOUT_MS,
+          },
+          (error, stdout, stderr) => {
+            if (error) {
+              const processError = error as CliProcessError;
+              processError.stdout = stdout;
+              processError.stderr = stderr;
+              rejectResult(processError);
+              return;
+            }
+
+            resolveResult({ stderr, stdout });
+          }
+        );
+      }
+    );
+
+    return { exitCode: 0, ...result };
+  } catch (error) {
+    const processError = error as CliProcessError;
+
+    if (processError.killed || typeof processError.code !== "number") {
+      throw error;
+    }
+
+    return {
+      exitCode: processError.code,
+      stderr: processError.stderr ?? "",
+      stdout: processError.stdout ?? "",
+    };
+  }
+};
+
+let fixtureServer: Server | undefined;
+let crossOriginServer: Server | undefined;
+let fixtureOrigin = "";
+let crossOrigin = "";
+let emptyWorkingDirectory = "";
+
+const listenOnEphemeralPort = async (
+  server: Server,
+  description: string
+): Promise<string> => {
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(0, "127.0.0.1", resolveListen);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error(`${description} did not bind to a TCP port.`);
+  }
+
+  return `http://127.0.0.1:${address.port}`;
+};
+
+const closeServer = async (server: Server | undefined): Promise<void> => {
+  if (!server) {
+    return;
+  }
+
+  await new Promise<void>((resolveClose, rejectClose) => {
+    server.close((error) => {
+      if (error) {
+        rejectClose(error);
+        return;
+      }
+      resolveClose();
+    });
+  });
+};
+
+test.beforeAll(async () => {
+  emptyWorkingDirectory = await mkdtemp(
+    join(tmpdir(), "shadscan-overflow-e2e-")
+  );
+  crossOriginServer = createServer((_request, response) => {
+    response.writeHead(200, {
+      "cache-control": "no-store",
+      "content-type": "text/html; charset=utf-8",
+    });
+    response.end(
+      "<!doctype html><html><head><title>Cross origin</title></head><body><main>Cross origin target</main></body></html>"
+    );
+  });
+  crossOrigin = await listenOnEphemeralPort(
+    crossOriginServer,
+    "The cross-origin overflow fixture server"
+  );
+  fixtureServer = createServer((request, response) => {
+    const requestUrl = new URL(
+      request.url ?? "/",
+      `http://${request.headers.host ?? "127.0.0.1"}`
+    );
+
+    if (requestUrl.pathname === "/redirect-same") {
+      response.writeHead(302, {
+        "cache-control": "no-store",
+        location: "/fits?redirected=private#result",
+      });
+      response.end();
+      return;
+    }
+
+    if (requestUrl.pathname === "/redirect-cross") {
+      response.writeHead(302, {
+        "cache-control": "no-store",
+        location: `${crossOrigin}/fits?token=must-not-leak#private`,
+      });
+      response.end();
+      return;
+    }
+
+    if (requestUrl.pathname === "/plain-text") {
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        "content-type": "text/plain; charset=utf-8",
+      });
+      response.end("Successful status, wrong content type");
+      return;
+    }
+
+    const markup = fixtureMarkup(requestUrl.pathname);
+
+    if (markup === null) {
+      response.writeHead(404, {
+        "cache-control": "no-store",
+        "content-type": "text/html; charset=utf-8",
+      });
+      response.end("<!doctype html><title>Missing</title><p>Not found</p>");
+      return;
+    }
+
+    response.writeHead(200, {
+      "cache-control": "no-store",
+      "content-type": "text/html; charset=utf-8",
+    });
+    response.end(
+      `<!doctype html><html><head><title>Fixture</title></head><body>${markup}</body></html>`
+    );
+  });
+  fixtureOrigin = await listenOnEphemeralPort(
+    fixtureServer,
+    "The overflow fixture server"
+  );
+});
+
+test.afterAll(async () => {
+  try {
+    await Promise.all([
+      closeServer(fixtureServer),
+      closeServer(crossOriginServer),
+    ]);
+  } finally {
+    if (emptyWorkingDirectory !== "") {
+      await rm(emptyWorkingDirectory, { force: true, recursive: true });
+    }
+  }
+});
+
+test("passes fitting, contained, subpixel, vertical, and settled layouts", async () => {
+  const secret = "must-not-appear";
+  const result = await runOverflowCheck([
+    "--check-overflow",
+    `${fixtureOrigin}/fits?token=${secret}#private`,
+    "--route",
+    "/local-scroller",
+    "--route",
+    "/subpixel",
+    "--route",
+    "/vertical-only",
+    "--route",
+    "/delayed-fit",
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe("");
+  expect(result.stdout).not.toContain(secret);
+
+  const report = JSON.parse(result.stdout) as OverflowReport;
+  expect(report).toMatchObject({
+    kind: "overflow-check",
+    schemaVersion: 1,
+    severity: "critical",
+    status: "pass",
+    summary: {
+      failed: 0,
+      maximumOverflowPx: 0,
+      measurements: 10,
+    },
+  });
+  const mobileMeasurements = report.results.filter(
+    ({ viewport }) => viewport.name === "mobile"
+  );
+  const desktopMeasurements = report.results.filter(
+    ({ viewport }) => viewport.name === "desktop"
+  );
+  expect(mobileMeasurements).toHaveLength(5);
+  expect(desktopMeasurements).toHaveLength(5);
+  expect(
+    mobileMeasurements.every(
+      ({ viewport }) => viewport.width === 320 && viewport.height === 820
+    )
+  ).toBe(true);
+  expect(
+    desktopMeasurements.every(
+      ({ viewport }) => viewport.width === 1440 && viewport.height === 1000
+    )
+  ).toBe(true);
+});
+
+test("detects document overflow across layout and rendering mechanisms", async () => {
+  const result = await runOverflowCheck([
+    "--check-overflow",
+    `${fixtureOrigin}/one-pixel`,
+    "--route",
+    "/forced-scrollbar",
+    "--route",
+    "/translated",
+    "--route",
+    "/absolute",
+    "--route",
+    "/pseudo",
+    "--route",
+    "/svg",
+    "--route",
+    "/rtl-left",
+    "--route",
+    "/root-hidden",
+    "--route",
+    "/root-clip",
+    "--route",
+    "/open-shadow-root",
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toBe("");
+
+  const report = JSON.parse(result.stdout) as OverflowReport;
+  expect(report).toMatchObject({
+    kind: "overflow-check",
+    schemaVersion: 1,
+    severity: "critical",
+    status: "fail",
+    summary: {
+      failed: 18,
+      maximumOverflowPx: 1,
+      measurements: 20,
+    },
+  });
+
+  const onePixelMobile = report.results.find(
+    ({ page, viewport }) => page === "/one-pixel" && viewport.name === "mobile"
+  );
+  expect(onePixelMobile).toMatchObject({
+    clientWidth: 320,
+    overflowPx: 1,
+    scrollWidth: 321,
+    status: "fail",
+  });
+
+  const onePixelDesktop = report.results.find(
+    ({ page, viewport }) => page === "/one-pixel" && viewport.name === "desktop"
+  );
+  expect(onePixelDesktop).toMatchObject({
+    overflowPx: 0,
+    status: "pass",
+  });
+
+  const forcedMeasurements = report.results.filter(
+    ({ page }) => page === "/forced-scrollbar"
+  );
+  expect(forcedMeasurements).toHaveLength(2);
+  expect(
+    forcedMeasurements.every(
+      ({ forcedScrollbar, status }) => forcedScrollbar && status === "fail"
+    )
+  ).toBe(true);
+
+  const desktopSvg = report.results.find(
+    ({ page, viewport }) => page === "/svg" && viewport.name === "desktop"
+  );
+  const mobileSvg = report.results.find(
+    ({ page, viewport }) => page === "/svg" && viewport.name === "mobile"
+  );
+  expect(desktopSvg).toMatchObject({ overflowPx: 1, status: "fail" });
+  expect(mobileSvg).toMatchObject({ overflowPx: 0, status: "pass" });
+
+  for (const page of [
+    "/translated",
+    "/absolute",
+    "/pseudo",
+    "/rtl-left",
+    "/root-hidden",
+    "/root-clip",
+    "/open-shadow-root",
+  ]) {
+    expect(
+      report.results
+        .filter((measurement) => measurement.page === page)
+        .every((measurement) => measurement.status === "fail")
+    ).toBe(true);
+  }
+
+  const shadowMeasurements = report.results.filter(
+    ({ page }) => page === "/open-shadow-root"
+  );
+  expect(
+    shadowMeasurements.every(({ culprits }) =>
+      culprits.some(
+        ({ descriptor }) => descriptor === '[data-slot="shadow-overflow"]'
+      )
+    )
+  ).toBe(true);
+});
+
+test("measures the default motion profile and document coordinates", async () => {
+  const result = await runOverflowCheck([
+    "--check-overflow",
+    `${fixtureOrigin}/hash-overflow#target`,
+    "--route",
+    "/motion-overflow",
+    "--route",
+    "/many-culprits",
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toBe("");
+  expect(JSON.parse(result.stdout)).toMatchObject({
+    status: "fail",
+    summary: {
+      failed: 5,
+      maximumOverflowPx: 681,
+      measurements: 6,
+    },
+  });
+  const report = JSON.parse(result.stdout) as OverflowReport;
+  const hashMobile = report.results.find(
+    ({ page, viewport }) =>
+      page === "/hash-overflow#[redacted]" && viewport.name === "mobile"
+  );
+  expect(hashMobile?.culprits[0]?.descriptor).toBe("#target");
+  const manyCulpritMeasurements = report.results.filter(
+    ({ page }) => page === "/many-culprits"
+  );
+  expect(manyCulpritMeasurements).toHaveLength(2);
+  expect(
+    manyCulpritMeasurements.every(({ culprits }) => culprits.length === 3)
+  ).toBe(true);
+});
+
+test("waits for fonts and follows a same-origin HTTP redirect", async () => {
+  const result = await runOverflowCheck([
+    "--check-overflow",
+    `${fixtureOrigin}/redirect-same`,
+    "--route",
+    "/delayed-font-ready",
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe("");
+  expect(result.stdout).not.toContain("redirected=private");
+  const report = JSON.parse(result.stdout) as OverflowReport;
+  expect(report).toMatchObject({
+    status: "pass",
+    summary: { failed: 0, maximumOverflowPx: 0, measurements: 4 },
+  });
+  expect(report.durationMs).toBeGreaterThanOrEqual(1400);
+  expect(
+    report.results
+      .filter(({ page }) => page === "/redirect-same")
+      .every(
+        ({ finalPath, httpStatus, status }) =>
+          finalPath === "/fits" && httpStatus === 200 && status === "pass"
+      )
+  ).toBe(true);
+  expect(
+    report.results
+      .filter(({ page }) => page === "/delayed-font-ready")
+      .every(({ status }) => status === "pass")
+  ).toBe(true);
+});
+
+test("rejects unstable, cross-origin, non-HTML, and unavailable targets", async () => {
+  const cases = [
+    {
+      expectedCode: "OVERFLOW_PAGE_NOT_STABLE",
+      expectedSecret: null,
+      target: `${fixtureOrigin}/unstable-width`,
+    },
+    {
+      expectedCode: "OVERFLOW_TARGET_UNAVAILABLE",
+      expectedSecret: "must-not-leak",
+      target: `${fixtureOrigin}/redirect-cross`,
+    },
+    {
+      expectedCode: "OVERFLOW_TARGET_UNAVAILABLE",
+      expectedSecret: null,
+      target: `${fixtureOrigin}/plain-text`,
+    },
+    {
+      expectedCode: "OVERFLOW_TARGET_UNAVAILABLE",
+      expectedSecret: null,
+      target: "http://127.0.0.1:1/unavailable",
+    },
+  ];
+
+  for (const { expectedCode, expectedSecret, target } of cases) {
+    const result = await runOverflowCheck([
+      "--check-overflow",
+      target,
+      "--browser-executable",
+      chromium.executablePath(),
+      "--json",
+      "--no-interactive",
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+    if (expectedSecret) {
+      expect(result.stderr).not.toContain(expectedSecret);
+    }
+    expect(JSON.parse(result.stderr)).toMatchObject({
+      error: { code: expectedCode },
+      schemaVersion: 1,
+    });
+  }
+});
+
+test("keeps operational failures off stdout", async () => {
+  const result = await runOverflowCheck([
+    "--check-overflow",
+    `${fixtureOrigin}/missing`,
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toBe("");
+  expect(JSON.parse(result.stderr)).toMatchObject({
+    error: {
+      code: "OVERFLOW_TARGET_UNAVAILABLE",
+    },
+    schemaVersion: 1,
+  });
+
+  const clientRedirect = await runOverflowCheck([
+    "--check-overflow",
+    `${fixtureOrigin}/client-redirect`,
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(clientRedirect.exitCode).toBe(1);
+  expect(clientRedirect.stdout).toBe("");
+  expect(clientRedirect.stderr).not.toContain("must-not-leak");
+  expect(JSON.parse(clientRedirect.stderr)).toMatchObject({
+    error: {
+      code: "OVERFLOW_TARGET_UNAVAILABLE",
+    },
+    schemaVersion: 1,
+  });
+
+  const client404 = await runOverflowCheck([
+    "--check-overflow",
+    `${fixtureOrigin}/client-404`,
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(client404.exitCode).toBe(1);
+  expect(client404.stdout).toBe("");
+  expect(JSON.parse(client404.stderr)).toMatchObject({
+    error: {
+      code: "OVERFLOW_TARGET_UNAVAILABLE",
+    },
+    schemaVersion: 1,
+  });
+
+  const immediate404 = await runOverflowCheck([
+    "--check-overflow",
+    `${fixtureOrigin}/immediate-404`,
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(immediate404.exitCode).toBe(1);
+  expect(immediate404.stdout).toBe("");
+  expect(JSON.parse(immediate404.stderr)).toMatchObject({
+    error: {
+      code: "OVERFLOW_TARGET_UNAVAILABLE",
+    },
+    schemaVersion: 1,
+  });
+
+  const clientBlob = await runOverflowCheck([
+    "--check-overflow",
+    `${fixtureOrigin}/client-blob`,
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(clientBlob.exitCode).toBe(1);
+  expect(clientBlob.stdout).toBe("");
+  expect(JSON.parse(clientBlob.stderr)).toMatchObject({
+    error: {
+      code: "OVERFLOW_TARGET_UNAVAILABLE",
+    },
+    schemaVersion: 1,
+  });
+});


### PR DESCRIPTION
## Summary

- add a standalone `--check-overflow <url>` mode for already-running local or deployed apps
- measure each requested page in isolated Chromium contexts at 320×820 and 1440×1000
- exit critically on any document-level horizontal overflow or forced root scrollbar, with bounded culprit evidence and versioned JSON output
- keep the existing 62-rule static audit, score, ruleset, hosted API, MCP server, web scanner, and GitHub Action behavior unchanged

## CLI contract

```bash
pnpm dlx @shadscan/cli --check-overflow http://localhost:3000
pnpm dlx @shadscan/cli --check-overflow https://preview.example.com --route /dashboard --json
```

The target must already be running. This mode bypasses project discovery, never runs project scripts, and works from an empty directory. A clean complete matrix exits 0; overflow exits 1 with a report on stdout; browser/navigation/readiness failures exit 1 with stdout empty and a stable stderr error.

## Safety and packaging

- lazy-load and externalize `playwright-core` only from the CLI browser path
- block cross-origin top-level navigation and reject non-HTTP(S), non-HTML, unsuccessful, unstable, or incomplete targets
- use fresh browser contexts with blocked service workers and no persisted state
- redact query/hash values and bound routes, DOM traversal, culprit output, duration, and report size
- verify Playwright is absent from hosted runtime imports and Next traces
- exercise the exact packed npm artifact with a real Chromium pass/fail smoke

## Verification

- `pnpm check`
- `pnpm docs:check`
- `pnpm --filter ./packages/cli typecheck`
- `pnpm typecheck`
- `pnpm cli:test` — 724 passed
- `pnpm ci:test-api` — 140 passed
- `pnpm ci:test-web` — 169 passed
- `pnpm ci:test-e2e` — 73 passed
- `pnpm audit:dependencies` — no known vulnerabilities
- `pnpm audit:self` — 100/100 (A)
- `pnpm build` + `pnpm verify:trace`
- `pnpm cli:smoke`
- packed browser smoke for clean and critical-fail outcomes

## Notes

This intentionally does not add a catalog rule or change the /stats rule count. It is a separate rendered verification command, so current local static workflows remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone `--check-overflow <url>` CLI mode for detecting horizontal overflow across mobile and desktop viewports.
  * Supports multiple same-origin routes, human-readable or JSON reports, configurable browser executables, and actionable culprit details.
  * Added validation, privacy safeguards, exit statuses, and clear handling of operational versus page-level failures.

* **Documentation**
  * Documented usage, supported options, output formats, browser setup, limitations, and automation examples across CLI and web documentation.

* **Tests**
  * Added comprehensive unit, integration, end-to-end, and packaged CLI coverage for overflow detection and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->