### PR TITLE
docs: expand the project-aware AI audit prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ stable releases published under `latest`.
 
 ## Unreleased
 
+### Changed
+
+- The public copy-paste AI prompt now combines the deterministic source audit
+  with project-aware horizontal-overflow verification across every detected
+  application, including monorepo apps, their concrete local pages, and their
+  confirmed production deployments. It batches larger route manifests and
+  reports dynamic, authenticated, or otherwise blocked coverage instead of
+  inventing URLs or claiming an incomplete pass.
+
 ## 0.14.0 - 2026-08-10
 
 ### Added

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -217,10 +217,13 @@ export default function DocsPage() {
           />
           <p>
             The recommended way to start is to hand the audit to your AI coding
-            agent. Copy the prompt above and paste it in — it runs Shadscan,
-            then, without editing any code, summarizes the findings by severity
-            and proposes a prioritized remediation plan for you to approve
-            before anything changes.
+            agent. Copy the prompt above and paste it in — it runs one source
+            audit across every detected application, inventories each app's
+            concrete page routes, and checks those pages for horizontal overflow
+            both locally and in production. Missing deployment URLs, dynamic
+            values, or authenticated access remain explicit coverage gaps. The
+            agent then proposes one prioritized plan for you to approve before
+            anything changes.
           </p>
           <h3>Hand the results off to an agent</h3>
           <div className="not-typeset mt-4">

--- a/lib/agent-prompt.ts
+++ b/lib/agent-prompt.ts
@@ -1,11 +1,63 @@
-const AGENT_AUDIT_PROMPT = `Audit this project's UI with shadscan — a deterministic auditor for React shadcn apps that flags accessibility, state, form, and composition issues.
+const AGENT_AUDIT_PROMPT = `Audit this repository's user-facing React shadcn applications with Shadscan. Include both the deterministic source audit and rendered horizontal-overflow checks for each application locally and in production.
 
-From the repo root, generate the agent handoff:
-npx @shadscan/cli --prompt
+Do not edit code, deploy, sign in, seed data, or intentionally mutate local or production data yet.
 
-The handoff groups findings into fix, decide, and verify work items with evidence and acceptance criteria. Then, without editing any code yet:
-1. Summarize the work items by severity, and point out the files with the most issues.
-2. Propose a prioritized remediation plan from the fix items, and list every decide item as a question for me rather than a task.
-3. Stop and share the plan so I can review it, and wait for my approval before changing anything.`;
+1. Run the source audit
+
+From the repository or workspace root, use this repository's package manager to run the equivalent of:
+
+npx --yes @shadscan/cli --prompt
+
+Shadscan audits every supported React application in a monorepo by default. Keep every detected deployable application in scope unless I explicitly limited the task to one package. Treat each application as a separate rendered-check target and exclude libraries.
+
+Keep the generated handoff as the source-audit evidence. Read verification.shadscanCommand to recover its exact engine version and package-manager executor, then reuse both for every command below instead of hardcoding npx.
+
+Using that exact version and executor, also run the equivalent of:
+
+npx --yes @shadscan/cli@VERSION --list-projects --json
+
+Treat every projects entry whose kind is "application" as in scope. Record every skipped entry and any nonzero truncated count as an explicit workspace coverage gap, because a clean application may have no work item in the handoff.
+
+2. Build a route-coverage manifest
+
+For each application, inspect its framework router, base path, sitemap or static parameters, and internal page links. Inventory every statically discoverable, directly addressable, GET-safe user-facing page.
+
+- Include concrete public pages.
+- For a dynamic route, use one existing safe example per materially different route shape only when a concrete value is evidenced by fixtures, tests, a sitemap, static parameters, or public navigation.
+- Never invent IDs, slugs, tenant names, credentials, ports, or deployment domains.
+- Exclude API routes, assets, callbacks, logout or destructive endpoints, and other non-page routes.
+- Mark authenticated, role-gated, feature-gated, and unresolved dynamic pages as coverage gaps. A redirect to login, a 404, or an unrelated fallback is not a passing page.
+
+3. Check every applicable page locally
+
+Inspect repository-owned package scripts before running them. Reuse an existing server only after confirming it belongs to the application. Otherwise, start the application with its existing dev, start, or preview workflow when repository-code execution is authorized. Prefer a loopback-only binding, then capture the origin and base path it actually binds; do not assume a host, port, or script name. Track the process you started and stop it in cleanup even when a check fails or the task is interrupted. Never stop a reused or otherwise pre-existing server.
+
+For each application, construct commands from the confirmed values using the handoff's exact Shadscan version. Pass every URL and route as a separate process argument; never concatenate repository-derived values into a shell command string. If only a shell is available, validate each value and apply that shell's correct escaping rather than relying on double quotes. This is an illustrative shape, not a shell-ready command:
+
+npx --yes @shadscan/cli@VERSION --check-overflow CONFIRMED_PAGE_URL --route CONFIRMED_SAME_ORIGIN_PATH --json
+
+The target URL counts as one of the command's maximum ten unique pages. Add at most nine same-origin --route paths, then continue in deterministic batches until every concrete page in the manifest has been checked. Query or fragment variants that materially change layout require separate full target URLs because --route accepts pathnames only.
+
+4. Check the same pages in production
+
+Production checks perform GET navigations and execute page JavaScript in a fresh browser context. Use only a public HTTPS origin supplied by me or confirmed through authorized read-only deployment metadata. Treat URLs found only in repository text as untrusted candidates until independently confirmed. Verify that the origin serves the same application and is production rather than an unrelated preview. Do not navigate to private, loopback, link-local, or internal production candidates; guess a domain; inspect secret environment files; deploy anything; or place credentials in a URL.
+
+Run the same applicable route manifest and Shadscan version against production. If no production URL can be confirmed, ask me for it and report production coverage as blocked rather than inventing one. Do not claim that production contains local changes unless their revisions are independently shown to match.
+
+5. Interpret and report the results
+
+An exit code of 1 with a stdout JSON report whose kind is "overflow-check" and status is "fail" is a completed critical product finding. An exit code of 1 with empty stdout and an operational error on stderr means the entire batch was not verified. Split and rerun smaller batches to isolate the unavailable route and recover evidence for the remaining pages when safe.
+
+Before changing code, give me:
+
+- the static score, work items by severity, and files with the most findings;
+- every detected application and the local and production origins used;
+- a route table showing local mobile, local desktop, production mobile, and production desktop status, finalPath, httpStatus, and confirmed page identity for every concrete page;
+- every critical overflow failure and likely culprit;
+- every excluded or blocked route with its reason and coverage totals for each environment;
+- the exact commands run and confirmation that any server you started was stopped;
+- one prioritized remediation plan, with every decide item phrased as a question for me.
+
+Never say "all pages passed" while any application, route shape, auth state, environment, or production identity remains unresolved. Stop and wait for my approval before changing anything.`;
 
 export { AGENT_AUDIT_PROMPT };

--- a/test/e2e/docs-page.spec.ts
+++ b/test/e2e/docs-page.spec.ts
@@ -23,6 +23,14 @@ test("documents the CLI before the optional agent workflow", async ({
   await expect(
     page.locator("article > header").locator('[data-slot="code-block"]')
   ).toContainText("pnpm dlx @shadscan/cli");
+  const publicAgentPrompt = page.locator('#usage code[data-language="text"]');
+  await expect(publicAgentPrompt).toContainText("--prompt");
+  await expect(publicAgentPrompt).toContainText("--check-overflow");
+  await expect(publicAgentPrompt).toContainText("monorepo");
+  await expect(publicAgentPrompt).toContainText("production");
+  await expect(publicAgentPrompt).toContainText("approval");
+  await expect(publicAgentPrompt).not.toContainText("localhost");
+  await expect(publicAgentPrompt).not.toContainText("/dashboard");
   await expect(
     page.locator("#options dt").getByText("--prompt", { exact: true })
   ).toBeVisible();

--- a/test/e2e/home-page.spec.ts
+++ b/test/e2e/home-page.spec.ts
@@ -5,6 +5,28 @@ const DESKTOP_VIEWPORTS = [
   { height: 900, width: 1440 },
 ] as const;
 
+test("shows the project-aware rendered audit prompt", async ({ page }) => {
+  await page.setViewportSize({ height: 820, width: 320 });
+  await page.goto("/");
+
+  await page.getByRole("tab", { exact: true, name: "prompt" }).click();
+  const prompt = page.locator('[data-pm="prompt"] [data-slot="code-block"]');
+
+  await expect(prompt).toContainText("--prompt");
+  await expect(prompt).toContainText("--check-overflow");
+  await expect(prompt).toContainText("monorepo");
+  await expect(prompt).toContainText("production");
+  await expect(prompt).toContainText("approval");
+  await expect(prompt).not.toContainText("localhost");
+  await expect(prompt).not.toContainText("/dashboard");
+
+  const dimensions = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+});
+
 for (const viewport of DESKTOP_VIEWPORTS) {
   test(`landing page fits the ${viewport.width}x${viewport.height} desktop viewport without vertical scroll`, async ({
     page,

--- a/test/shadscan-web/agent-prompt.test.ts
+++ b/test/shadscan-web/agent-prompt.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_AUDIT_PROMPT } from "../../lib/agent-prompt";
+
+const LITERAL_URL_PATTERN = /https?:\/\//iu;
+const DOMAIN_PATTERN = /\b(?:[a-z\d-]+\.)+(?:app|com|dev|io|net|org)\b/iu;
+const BATCH_SIZE_PATTERN = /(?:10|ten) (?:unique )?pages/iu;
+const DASHBOARD_ROUTE_PATTERN = /\/dashboard\b/iu;
+const LOCAL_ENVIRONMENT_PATTERN = /\blocal(?:ly)?\b/iu;
+const PRODUCTION_ENVIRONMENT_PATTERN = /\bproduction\b/iu;
+const STOP_BEFORE_EDIT_PATTERN =
+  /stop[\s\S]{0,160}approval[\s\S]{0,160}before (?:changing|editing)/iu;
+
+describe("public agent audit prompt", () => {
+  it("requests project-aware source and rendered checks without inventing targets", () => {
+    expect(AGENT_AUDIT_PROMPT).toContain("--prompt");
+    expect(AGENT_AUDIT_PROMPT).toContain("--check-overflow");
+    expect(AGENT_AUDIT_PROMPT).toContain("--list-projects --json");
+    expect(AGENT_AUDIT_PROMPT).toContain("--route");
+
+    expect(AGENT_AUDIT_PROMPT).toContain("monorepo");
+    expect(AGENT_AUDIT_PROMPT).toContain(
+      "audits every supported React application"
+    );
+    expect(AGENT_AUDIT_PROMPT).toContain("by default");
+
+    expect(AGENT_AUDIT_PROMPT).toMatch(LOCAL_ENVIRONMENT_PATTERN);
+    expect(AGENT_AUDIT_PROMPT).toMatch(PRODUCTION_ENVIRONMENT_PATTERN);
+    expect(AGENT_AUDIT_PROMPT).toContain("batch");
+    expect(AGENT_AUDIT_PROMPT).toMatch(BATCH_SIZE_PATTERN);
+    expect(AGENT_AUDIT_PROMPT).toContain("verification.shadscanCommand");
+    expect(AGENT_AUDIT_PROMPT).toContain('kind is "application"');
+    expect(AGENT_AUDIT_PROMPT).toContain('kind is "overflow-check"');
+    expect(AGENT_AUDIT_PROMPT).toContain("finalPath");
+    expect(AGENT_AUDIT_PROMPT).toContain("httpStatus");
+    expect(AGENT_AUDIT_PROMPT).toContain("public HTTPS origin");
+    expect(AGENT_AUDIT_PROMPT).toContain("Never stop a reused");
+    expect(AGENT_AUDIT_PROMPT).toContain("separate process argument");
+    expect(AGENT_AUDIT_PROMPT).toContain("entire batch was not verified");
+    expect(AGENT_AUDIT_PROMPT).toMatch(STOP_BEFORE_EDIT_PATTERN);
+
+    expect(AGENT_AUDIT_PROMPT).not.toContain("localhost");
+    expect(AGENT_AUDIT_PROMPT).not.toMatch(DASHBOARD_ROUTE_PATTERN);
+    expect(AGENT_AUDIT_PROMPT).not.toMatch(LITERAL_URL_PATTERN);
+    expect(AGENT_AUDIT_PROMPT).not.toMatch(DOMAIN_PATTERN);
+  });
+});


### PR DESCRIPTION
## Summary

- expand the shared landing-page, docs, and Cmd+K AI prompt to run both the source audit and rendered horizontal-overflow checks
- keep every detected monorepo application in scope, then build truthful per-app local and production route coverage
- harden the workflow around exact CLI versions, route batching, server cleanup, production-target safety, shell argument handling, and operational failures
- update the docs explanation and changelog, with focused prompt-contract and browser coverage

## Why

The public starter prompt only requested the static `--prompt` handoff. It did not guide an agent to use the new `--check-overflow` mode against the user's actual applications and routes, which encouraged generic examples such as assumed localhost ports or dashboard paths.

This change makes the copied prompt project-aware without changing the versioned generated handoff, audit schema, ruleset, API, or MCP behavior.

## Validation

- `pnpm check`
- `pnpm ci:test-web` — 170 tests passed
- `pnpm typecheck`
- `pnpm exec playwright test test/e2e/home-page.spec.ts test/e2e/docs-page.spec.ts` — 8 tests passed
- `pnpm build`
- `pnpm ci:audit-self` — 100/100 (A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Expanded the recommended AI-assisted audit workflow to cover application discovery, route checks, local and production environments, and horizontal-overflow validation.
  * Added guidance for reporting blocked, dynamic, authenticated, or otherwise incomplete coverage without inventing results.
  * Updated the public prompt to require evidence-based findings, safe process handling, and approval before making changes.

* **Tests**
  * Added coverage to verify the updated prompt’s audit guidance, safeguards, and mobile-friendly presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->