### PR TITLE
fix(site): collapse agent prompt previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ stable releases published under `latest`.
   confirmed production deployments. It batches larger route manifests and
   reports dynamic, authenticated, or otherwise blocked coverage instead of
   inventing URLs or claiming an incomplete pass.
+- The landing-page and documentation prompt previews now show ten rows by
+  default, with accessible Read more and Read less controls that leave copied
+  prompt text complete.
 
 ## 0.14.0 - 2026-08-10
 

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { CodeBlockCommand } from "@/components/code-block-command";
+import { CollapsibleCode } from "@/components/collapsible-code";
 import { CopyButton } from "@/components/copy-button";
 import { DocsOnThisPage } from "@/components/docs-on-this-page";
 import { AGENT_AUDIT_PROMPT } from "@/lib/agent-prompt";
@@ -115,6 +116,7 @@ const CLI_OPTIONS = [
 
 interface DocsCodeBlockProps {
   code: string;
+  collapsible?: boolean;
   label: string;
   language: "bash" | "markdown" | "text";
 }
@@ -130,7 +132,12 @@ const getCliCommands = (cliArguments = "") => {
   } as const;
 };
 
-function DocsCodeBlock({ code, label, language }: DocsCodeBlockProps) {
+function DocsCodeBlock({
+  code,
+  collapsible = false,
+  label,
+  language,
+}: DocsCodeBlockProps) {
   return (
     <div className="not-typeset relative mt-4 overflow-hidden border bg-code">
       <div className="flex h-10 items-center justify-between border-b px-4">
@@ -143,14 +150,24 @@ function DocsCodeBlock({ code, label, language }: DocsCodeBlockProps) {
           variant="ghost"
         />
       </div>
-      <pre className="whitespace-pre-wrap break-words p-4 text-sm leading-6">
-        <code
-          className="font-mono text-code-foreground"
-          data-language={language}
-        >
-          {code}
-        </code>
-      </pre>
+      {collapsible ? (
+        <CollapsibleCode
+          className="whitespace-pre-wrap break-words font-mono text-code-foreground"
+          code={code}
+          language={language}
+          preClassName="p-4 text-sm leading-6"
+        />
+      ) : (
+        <pre className="whitespace-pre-wrap break-words p-4 text-sm leading-6">
+          <code
+            className="font-mono text-code-foreground"
+            data-language={language}
+            data-slot="code-block"
+          >
+            {code}
+          </code>
+        </pre>
+      )}
     </div>
   );
 }
@@ -212,6 +229,7 @@ export default function DocsPage() {
           <h3>Run with an AI agent (recommended)</h3>
           <DocsCodeBlock
             code={AGENT_AUDIT_PROMPT}
+            collapsible
             label="Prompt"
             language="text"
           />

--- a/components/code-block-command.tsx
+++ b/components/code-block-command.tsx
@@ -3,6 +3,7 @@
 import { ScrollArea } from "@base-ui/react/scroll-area";
 import { TerminalIcon, TextAlignLeftIcon } from "@phosphor-icons/react";
 import { useMemo, useState } from "react";
+import { CollapsibleCode } from "@/components/collapsible-code";
 import { CopyButton } from "@/components/copy-button";
 import { IconSwap, IconSwapItem } from "@/components/icon-swap";
 import {
@@ -52,7 +53,10 @@ export function CodeBlockCommand({
   );
 
   const tabsFiltered = useMemo(
-    () => Object.entries(tabs).filter(([, value]) => !!value),
+    () =>
+      Object.entries(tabs).filter((entry): entry is [PackageManager, string] =>
+        Boolean(entry[1])
+      ),
     [tabs]
   );
 
@@ -104,21 +108,30 @@ export function CodeBlockCommand({
 
         {tabsFiltered.map(([key, value]) => (
           <TabsContent key={key} value={key}>
-            <pre
-              className="group/tabs-content-pre not-data-[pm=prompt]:overflow-x-auto overscroll-x-contain p-4 leading-6"
-              data-pm={key}
-            >
-              <code
-                className="font-mono text-muted-foreground text-sm/none group-data-[pm=prompt]/tabs-content-pre:whitespace-pre-wrap"
-                data-language="bash"
-                data-slot="code-block"
+            {key === "prompt" ? (
+              <div data-pm={key}>
+                <CollapsibleCode
+                  className="whitespace-pre-wrap font-mono text-muted-foreground text-sm leading-6"
+                  code={value}
+                  language="bash"
+                  preClassName="overscroll-x-contain p-4 leading-6"
+                />
+              </div>
+            ) : (
+              <pre
+                className="overflow-x-auto overscroll-x-contain p-4 leading-6"
+                data-pm={key}
               >
-                <span className="select-none group-data-[pm=prompt]/tabs-content-pre:hidden">
-                  ${" "}
-                </span>
-                {value}
-              </code>
-            </pre>
+                <code
+                  className="font-mono text-muted-foreground text-sm/none"
+                  data-language="bash"
+                  data-slot="code-block"
+                >
+                  <span className="select-none">$ </span>
+                  {value}
+                </code>
+              </pre>
+            )}
           </TabsContent>
         ))}
       </Tabs>

--- a/components/collapsible-code.tsx
+++ b/components/collapsible-code.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useId, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const DEFAULT_COLLAPSED_LINES = 10;
+
+interface CollapsibleCodeProps {
+  className?: string;
+  code: string;
+  collapsedLines?: number;
+  language: string;
+  preClassName?: string;
+}
+
+export function CollapsibleCode({
+  className,
+  code,
+  collapsedLines = DEFAULT_COLLAPSED_LINES,
+  language,
+  preClassName,
+}: CollapsibleCodeProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const baseId = useId();
+  const accessibleCodeId = `${baseId}-accessible`;
+  const lines = code.split("\n");
+  const preview = lines.slice(0, collapsedLines).join("\n");
+  const remainingLines = lines.slice(collapsedLines);
+  const remainder =
+    remainingLines.length > 0 ? `\n${remainingLines.join("\n")}` : "";
+  const isCollapsible = remainder.length > 0;
+
+  return (
+    <div data-slot="collapsible-code">
+      <pre
+        aria-hidden={isCollapsible ? true : undefined}
+        className={preClassName}
+      >
+        <code
+          className={cn("block", className)}
+          data-language={language}
+          data-slot="code-block"
+          style={
+            isCollapsible && !isExpanded
+              ? { maxHeight: `${collapsedLines}lh`, overflow: "hidden" }
+              : undefined
+          }
+        >
+          {code}
+        </code>
+      </pre>
+
+      {isCollapsible ? (
+        <div className="flex border-t px-1 py-1">
+          <code className="sr-only whitespace-pre-wrap" id={accessibleCodeId}>
+            {preview}
+            <span hidden={!isExpanded}>{remainder}</span>
+          </code>
+          <Button
+            aria-controls={accessibleCodeId}
+            aria-expanded={isExpanded}
+            onClick={() => {
+              setIsExpanded((expanded) => !expanded);
+            }}
+            size="xs"
+            type="button"
+            variant="link"
+          >
+            {isExpanded ? "Read less" : "Read more"}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/test/e2e/docs-page.spec.ts
+++ b/test/e2e/docs-page.spec.ts
@@ -1,5 +1,6 @@
 import AxeBuilder from "@axe-core/playwright";
-import { expect, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { AGENT_AUDIT_PROMPT } from "../../lib/agent-prompt";
 
 const VIEWPORTS = [
   { height: 820, width: 320 },
@@ -7,6 +8,115 @@ const VIEWPORTS = [
   { height: 900, width: 768 },
   { height: 1000, width: 1440 },
 ] as const;
+
+const expectNoDocumentOverflow = async (page: Page): Promise<void> => {
+  const dimensions = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+};
+
+const expectNoSevereAxeViolations = async (page: Page): Promise<void> => {
+  const results = await new AxeBuilder({ page }).analyze();
+  const severeViolations = results.violations.filter(
+    ({ impact }) => impact === "serious" || impact === "critical"
+  );
+  expect(severeViolations, JSON.stringify(severeViolations, null, 2)).toEqual(
+    []
+  );
+};
+
+const getControlledRegion = async (
+  page: Page,
+  control: Locator
+): Promise<Locator> => {
+  const controlledId = await control.getAttribute("aria-controls");
+  if (!controlledId) {
+    throw new Error(
+      "The prompt disclosure must identify its controlled region"
+    );
+  }
+  const controlledRegion = page.locator(`[id=${JSON.stringify(controlledId)}]`);
+  await expect(controlledRegion).toHaveCount(1);
+  return controlledRegion;
+};
+
+const getPromptHeightMetrics = (
+  controlledRegion: Locator
+): Promise<{
+  clientHeight: number;
+  lineHeight: number;
+  scrollHeight: number;
+}> =>
+  controlledRegion.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    lineHeight: Number.parseFloat(getComputedStyle(element).lineHeight),
+    scrollHeight: element.scrollHeight,
+  }));
+
+test("expands and copies the full recommended prompt from a ten-line preview", async ({
+  page,
+}) => {
+  await page.goto("/docs");
+
+  const usage = page.locator("#usage");
+  const readMore = usage.getByRole("button", {
+    exact: true,
+    name: "Read more",
+  });
+  const prompt = usage.locator('code[data-language="text"]');
+
+  await expect(page.getByRole("button", { name: "Read more" })).toHaveCount(1);
+  await expect(readMore).toHaveAttribute("aria-expanded", "false");
+  const controlledRegion = await getControlledRegion(page, readMore);
+  expect(await controlledRegion.innerText()).toContain("--prompt");
+  expect(await controlledRegion.innerText()).not.toContain("--check-overflow");
+  const collapsedMetrics = await getPromptHeightMetrics(prompt);
+  expect(collapsedMetrics.scrollHeight).toBeGreaterThan(
+    collapsedMetrics.clientHeight
+  );
+  expect(
+    Math.abs(collapsedMetrics.clientHeight - collapsedMetrics.lineHeight * 10)
+  ).toBeLessThanOrEqual(1);
+
+  await page.getByRole("button", { exact: true, name: "Copy Prompt" }).click();
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(AGENT_AUDIT_PROMPT);
+  await expectNoSevereAxeViolations(page);
+
+  await readMore.focus();
+  await readMore.press("Enter");
+  const readLess = usage.getByRole("button", {
+    exact: true,
+    name: "Read less",
+  });
+  await expect(readLess).toBeFocused();
+  await expect(readLess).toHaveAttribute("aria-expanded", "true");
+  const expandedMetrics = await getPromptHeightMetrics(prompt);
+  expect(expandedMetrics.clientHeight).toBeGreaterThan(
+    collapsedMetrics.clientHeight
+  );
+  expect(expandedMetrics.scrollHeight).toBeLessThanOrEqual(
+    expandedMetrics.clientHeight + 1
+  );
+  expect(await controlledRegion.innerText()).toBe(AGENT_AUDIT_PROMPT);
+  await expectNoSevereAxeViolations(page);
+
+  await readLess.press("Space");
+  const collapsedControl = usage.getByRole("button", {
+    exact: true,
+    name: "Read more",
+  });
+  await expect(collapsedControl).toBeFocused();
+  await expect(collapsedControl).toHaveAttribute("aria-expanded", "false");
+  const recollapsedMetrics = await getPromptHeightMetrics(prompt);
+  expect(recollapsedMetrics.clientHeight).toBe(collapsedMetrics.clientHeight);
+  expect(recollapsedMetrics.scrollHeight).toBeGreaterThan(
+    recollapsedMetrics.clientHeight
+  );
+});
 
 test("documents the CLI before the optional agent workflow", async ({
   page,
@@ -24,6 +134,10 @@ test("documents the CLI before the optional agent workflow", async ({
     page.locator("article > header").locator('[data-slot="code-block"]')
   ).toContainText("pnpm dlx @shadscan/cli");
   const publicAgentPrompt = page.locator('#usage code[data-language="text"]');
+  await page
+    .locator("#usage")
+    .getByRole("button", { exact: true, name: "Read more" })
+    .click();
   await expect(publicAgentPrompt).toContainText("--prompt");
   await expect(publicAgentPrompt).toContainText("--check-overflow");
   await expect(publicAgentPrompt).toContainText("monorepo");
@@ -98,13 +212,7 @@ test("documents the CLI before the optional agent workflow", async ({
     })
   ).toBeVisible();
 
-  const results = await new AxeBuilder({ page }).analyze();
-  const severeViolations = results.violations.filter(
-    ({ impact }) => impact === "serious" || impact === "critical"
-  );
-  expect(severeViolations, JSON.stringify(severeViolations, null, 2)).toEqual(
-    []
-  );
+  await expectNoSevereAxeViolations(page);
 });
 
 for (const viewport of VIEWPORTS) {
@@ -112,10 +220,11 @@ for (const viewport of VIEWPORTS) {
     await page.setViewportSize(viewport);
     await page.goto("/docs");
 
-    const dimensions = await page.evaluate(() => ({
-      clientWidth: document.documentElement.clientWidth,
-      scrollWidth: document.documentElement.scrollWidth,
-    }));
-    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+    await expectNoDocumentOverflow(page);
+    await page
+      .locator("#usage")
+      .getByRole("button", { exact: true, name: "Read more" })
+      .click();
+    await expectNoDocumentOverflow(page);
   });
 }

--- a/test/e2e/home-page.spec.ts
+++ b/test/e2e/home-page.spec.ts
@@ -1,16 +1,108 @@
-import { expect, test } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { AGENT_AUDIT_PROMPT } from "../../lib/agent-prompt";
 
 const DESKTOP_VIEWPORTS = [
   { height: 720, width: 1280 },
   { height: 900, width: 1440 },
 ] as const;
 
-test("shows the project-aware rendered audit prompt", async ({ page }) => {
+const expectNoDocumentOverflow = async (page: Page): Promise<void> => {
+  const dimensions = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+};
+
+const expectNoSeverePromptAxeViolations = async (page: Page): Promise<void> => {
+  const results = await new AxeBuilder({ page })
+    .include('[data-slot="collapsible-code"]')
+    .analyze();
+  const severeViolations = results.violations.filter(
+    ({ impact }) => impact === "serious" || impact === "critical"
+  );
+  expect(severeViolations, JSON.stringify(severeViolations, null, 2)).toEqual(
+    []
+  );
+};
+
+const getControlledRegion = async (
+  page: Page,
+  control: Locator
+): Promise<Locator> => {
+  const controlledId = await control.getAttribute("aria-controls");
+  if (!controlledId) {
+    throw new Error(
+      "The prompt disclosure must identify its controlled region"
+    );
+  }
+  const controlledRegion = page.locator(`[id=${JSON.stringify(controlledId)}]`);
+  await expect(controlledRegion).toHaveCount(1);
+  return controlledRegion;
+};
+
+const getPromptHeightMetrics = (
+  controlledRegion: Locator
+): Promise<{
+  clientHeight: number;
+  lineHeight: number;
+  scrollHeight: number;
+}> =>
+  controlledRegion.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    lineHeight: Number.parseFloat(getComputedStyle(element).lineHeight),
+    scrollHeight: element.scrollHeight,
+  }));
+
+test("shows and copies the full project-aware prompt from a ten-line preview", async ({
+  page,
+}) => {
   await page.setViewportSize({ height: 820, width: 320 });
   await page.goto("/");
 
   await page.getByRole("tab", { exact: true, name: "prompt" }).click();
   const prompt = page.locator('[data-pm="prompt"] [data-slot="code-block"]');
+  const readMore = page.getByRole("button", {
+    exact: true,
+    name: "Read more",
+  });
+
+  await expect(readMore).toHaveAttribute("aria-expanded", "false");
+  const controlledRegion = await getControlledRegion(page, readMore);
+  expect(await controlledRegion.innerText()).toContain("--prompt");
+  expect(await controlledRegion.innerText()).not.toContain("--check-overflow");
+  const collapsedMetrics = await getPromptHeightMetrics(prompt);
+  expect(collapsedMetrics.scrollHeight).toBeGreaterThan(
+    collapsedMetrics.clientHeight
+  );
+  expect(
+    Math.abs(collapsedMetrics.clientHeight - collapsedMetrics.lineHeight * 10)
+  ).toBeLessThanOrEqual(1);
+
+  await page.getByRole("button", { exact: true, name: "Copy" }).click();
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(AGENT_AUDIT_PROMPT);
+
+  await expectNoDocumentOverflow(page);
+  await expectNoSeverePromptAxeViolations(page);
+
+  await readMore.focus();
+  await readMore.press("Enter");
+  const readLess = page.getByRole("button", {
+    exact: true,
+    name: "Read less",
+  });
+  await expect(readLess).toBeFocused();
+  await expect(readLess).toHaveAttribute("aria-expanded", "true");
+  const expandedMetrics = await getPromptHeightMetrics(prompt);
+  expect(expandedMetrics.clientHeight).toBeGreaterThan(
+    collapsedMetrics.clientHeight
+  );
+  expect(expandedMetrics.scrollHeight).toBeLessThanOrEqual(
+    expandedMetrics.clientHeight + 1
+  );
 
   await expect(prompt).toContainText("--prompt");
   await expect(prompt).toContainText("--check-overflow");
@@ -19,12 +111,24 @@ test("shows the project-aware rendered audit prompt", async ({ page }) => {
   await expect(prompt).toContainText("approval");
   await expect(prompt).not.toContainText("localhost");
   await expect(prompt).not.toContainText("/dashboard");
+  expect(await controlledRegion.innerText()).toBe(AGENT_AUDIT_PROMPT);
 
-  const dimensions = await page.evaluate(() => ({
-    clientWidth: document.documentElement.clientWidth,
-    scrollWidth: document.documentElement.scrollWidth,
-  }));
-  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+  await expectNoDocumentOverflow(page);
+  await expectNoSeverePromptAxeViolations(page);
+
+  await readLess.press("Space");
+  const collapsedControl = page.getByRole("button", {
+    exact: true,
+    name: "Read more",
+  });
+  await expect(collapsedControl).toBeFocused();
+  await expect(collapsedControl).toHaveAttribute("aria-expanded", "false");
+  const recollapsedMetrics = await getPromptHeightMetrics(prompt);
+  expect(recollapsedMetrics.clientHeight).toBe(collapsedMetrics.clientHeight);
+  expect(recollapsedMetrics.scrollHeight).toBeGreaterThan(
+    recollapsedMetrics.clientHeight
+  );
+  await expectNoDocumentOverflow(page);
 });
 
 for (const viewport of DESKTOP_VIEWPORTS) {


### PR DESCRIPTION
## Summary

- collapse the public AI prompt previews to ten rendered rows on the landing page and docs
- add accessible Read more and Read less controls while keeping the complete prompt available to assistive technology
- preserve full clipboard and Cmd+K prompt copy behavior
- verify collapsed and expanded states across responsive viewports

## Validation

- pnpm check
- pnpm ci:typecheck
- pnpm ci:test-web — 170 tests passed
- pnpm exec playwright test test/e2e/home-page.spec.ts test/e2e/docs-page.spec.ts — 9 tests passed
- pnpm build
- node_modules/.bin/shadscan --json — 100/100 (A)