### PR TITLE
feat(cli): introduce canonical rendered UI checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,33 @@ stable releases published under `latest`.
 
 ## Unreleased
 
+### Added
+
+- `--check-ui <url>` is now the public entry point for deterministic rendered
+  UI checks, with horizontal overflow as its first check and room for more
+  browser-based checks under the same command. The existing
+  `--check-overflow` flag remains a compatibility alias while help,
+  documentation, and agent prompts use the broader command.
+
 ### Changed
 
 - The public copy-paste AI prompt now combines the deterministic source audit
-  with project-aware horizontal-overflow verification across every detected
+  with project-aware rendered UI verification across every detected
   application, including monorepo apps, their concrete local pages, and their
-  confirmed production deployments. It batches larger route manifests and
-  reports dynamic, authenticated, or otherwise blocked coverage instead of
-  inventing URLs or claiming an incomplete pass.
+  confirmed production deployments. It uses `--check-ui`, batches larger route
+  manifests, and reports dynamic, authenticated, or otherwise blocked coverage
+  instead of inventing URLs or claiming an incomplete pass.
 - The landing-page and documentation prompt previews now show ten rows by
   default, with accessible Read more and Read less controls that leave copied
   prompt text complete.
+
+### Fixed
+
+- Rendered UI checks now follow narrowly validated canonical server redirects
+  between a conventional two-label apex host and its `www` host or from HTTP
+  to HTTPS, then pin the resolved origin for every requested route. HTTPS
+  downgrades, unrelated origins, project subdomains, and client-side
+  cross-origin navigations remain blocked.
 
 ## 0.14.0 - 2026-08-10
 

--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ pnpm dlx @shadscan/cli --list-projects
 # Scan one package of a monorepo instead of pooling every application
 pnpm dlx @shadscan/cli --project apps/web
 
-# Check a running app for horizontal overflow at mobile and desktop widths
-pnpm dlx @shadscan/cli --check-overflow http://localhost:3000
+# Run rendered UI checks at mobile and desktop widths
+pnpm dlx @shadscan/cli --check-ui http://localhost:3000
 
 # Include more same-origin routes (the target URL is always checked)
-pnpm dlx @shadscan/cli --check-overflow http://localhost:3000 --route /dashboard --route /settings
+pnpm dlx @shadscan/cli --check-ui http://localhost:3000 --route /dashboard --route /settings
 ```
 
 Use `--format human`, `--format json`, or `--format prompt` when output selection
@@ -134,10 +134,11 @@ needs to be explicit. Pin an exact package version in CI; unqualified commands
 resolve to the latest stable release. Run `pnpm dlx @shadscan/cli --help` for
 every option.
 
-## Check Rendered Horizontal Overflow
+## Check Rendered UI
 
-The focused `--check-overflow` command opens an already-running local or
-deployed app in isolated Chromium pages and checks these fixed CSS viewports:
+`--check-ui` is the home for deterministic checks that need a rendered page.
+Horizontal overflow is its first check. It opens an already-running local or
+deployed app in isolated Chromium pages at these fixed CSS viewports:
 
 - mobile: 320 × 820;
 - desktop: 1440 × 1000.
@@ -145,22 +146,28 @@ deployed app in isolated Chromium pages and checks these fixed CSS viewports:
 It reports a critical failure if the document has even one CSS pixel of
 horizontal overflow, or if the root or body forces a horizontal scrollbar.
 Likely culprit selectors are included when Shadscan can identify them. The
-target URL is always checked; repeat `--route` to add up to ten
-same-origin paths beginning with `/`. Routes cannot contain a query string or
-fragment.
+target URL is always checked; repeat `--route` to add up to ten paths beginning
+with `/`. Routes cannot contain a query string or fragment. When the initial
+request returns a narrowly validated server-side canonical redirect, Shadscan
+can follow a conventional two-label apex-to-`www` or `www`-to-apex host change
+and an HTTP-to-HTTPS upgrade. It pins the resulting origin for every additional
+route. For multi-label public suffixes, pass the canonical origin directly. Other
+cross-origin redirects, HTTPS downgrades, and client-side cross-origin
+navigations remain blocked. Reports use the resolved origin as their target;
+human output also identifies the originally requested origin when it changed.
 
-This command is separate from the default static source audit. It does not add
-a rule, score, or grade, and it leaves the 62-rule catalog and existing
-`mobile-overflow-absent` advisory unchanged. Shadscan does not start or build
-the target app, so start it yourself first or pass a deployed URL. The command
-can run outside a project directory.
+This rendered UI suite is separate from the default static source audit. Its
+overflow check does not add a rule, score, or grade, and it leaves the 62-rule
+catalog and existing `mobile-overflow-absent` advisory unchanged. Shadscan does
+not start or build the target app, so start it yourself first or pass a deployed
+URL. The command can run outside a project directory.
 
 ```bash
 # Human report
-pnpm dlx @shadscan/cli --check-overflow http://localhost:3000
+pnpm dlx @shadscan/cli --check-ui http://localhost:3000
 
 # Versioned JSON for automation
-pnpm dlx @shadscan/cli --check-overflow https://preview.example.com --json
+pnpm dlx @shadscan/cli --check-ui https://preview.example.com --json
 ```
 
 A clean result exits `0`. Detected overflow exits `1` after writing the
@@ -172,11 +179,11 @@ supported Chromium installation is available, run:
 pnpm dlx playwright-core@1.61.1 install chromium
 ```
 
-The overflow check performs GET navigations and executes the target's page
+Rendered UI checks perform GET navigations and execute the target's page
 JavaScript in fresh isolated browser contexts. It reads no project source,
 invokes no package scripts, and saves no page data. This focused mode is
-available only in the local CLI in its first release, not through MCP, the
-GitHub Action, hosted API, or web scanner.
+available only in the local CLI, not through MCP, the GitHub Action, hosted API,
+or web scanner.
 
 ## GitHub Action
 

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -45,16 +45,17 @@ const CLI_OPTIONS = [
   },
   {
     description:
-      "Check an already-running HTTP or HTTPS app for document-level horizontal overflow at fixed mobile and desktop viewports.",
-    option: "--check-overflow <url>",
+      "Run deterministic rendered UI checks against an already-running HTTP or HTTPS app. Horizontal overflow is the first check.",
+    option: "--check-ui <url>",
   },
   {
     description:
-      "Add a same-origin path beginning with /. Query strings and fragments are not accepted. Repeatable; ten total pages maximum.",
+      "Add a path beginning with / against the resolved origin. Query strings and fragments are not accepted. Repeatable; ten total pages maximum.",
     option: "--route <path>",
   },
   {
-    description: "Use a specific Chromium-family executable for overflow mode.",
+    description:
+      "Use a specific Chromium-family executable for rendered UI mode.",
     option: "--browser-executable <path>",
   },
   {
@@ -174,8 +175,8 @@ function DocsCodeBlock({
 
 export const metadata = createPageMetadata({
   description:
-    "Run Shadscan, check rendered horizontal overflow, inspect a progress-bar score, launch a coding agent, and enforce score thresholds.",
-  imageAlt: "Shadscan CLI source audits and rendered overflow checks",
+    "Run Shadscan, check rendered UI at mobile and desktop widths, inspect a progress-bar score, launch a coding agent, and enforce score thresholds.",
+  imageAlt: "Shadscan CLI source audits and rendered UI checks",
   imagePath: "/docs/opengraph-image",
   path: "/docs",
   title: "Shadscan CLI documentation",
@@ -217,7 +218,7 @@ export default function DocsPage() {
           <h2>Usage</h2>
           <DocsCodeBlock
             code={
-              "shadscan [path] [options]\nshadscan --check-overflow <url> [--route <path> ...]"
+              "shadscan [path] [options]\nshadscan --check-ui <url> [--route <path> ...]"
             }
             label="Syntax"
             language="bash"
@@ -237,7 +238,7 @@ export default function DocsPage() {
             The recommended way to start is to hand the audit to your AI coding
             agent. Copy the prompt above and paste it in — it runs one source
             audit across every detected application, inventories each app's
-            concrete page routes, and checks those pages for horizontal overflow
+            concrete page routes, and runs the rendered UI suite on those pages
             both locally and in production. Missing deployment URLs, dynamic
             values, or authenticated access remain explicit coverage gaps. The
             agent then proposes one prioritized plan for you to approve before
@@ -299,12 +300,12 @@ export default function DocsPage() {
           </p>
         </section>
 
-        <section id="overflow-check">
-          <h2>Check rendered horizontal overflow</h2>
+        <section id="ui-check">
+          <h2>Check rendered UI</h2>
           <div className="not-typeset mt-4">
             <CodeBlockCommand
               {...getCliCommands(
-                "--check-overflow http://localhost:3000 --route /dashboard"
+                "--check-ui http://localhost:3000 --route /dashboard"
               )}
             />
           </div>
@@ -313,9 +314,20 @@ export default function DocsPage() {
             install dependencies, build the app, or run its dev or start
             scripts. This mode checks the supplied URL from any directory, so it
             does not need a project or <code>package.json</code>. The target URL
-            is always included; repeat <code>--route</code> to check more
-            same-origin paths beginning with <code>/</code>, up to ten pages in
-            total. Routes cannot contain query strings or fragments.
+            is always included; repeat <code>--route</code> to check more paths
+            beginning with <code>/</code>, up to ten pages in total. Routes
+            cannot contain query strings or fragments.
+          </p>
+          <p>
+            The initial request may follow narrowly validated server-side
+            canonical redirects between a conventional two-label apex host and
+            its <code>www</code> host, and from HTTP to HTTPS. For multi-label
+            public suffixes, pass the canonical origin directly. Shadscan pins
+            the resolved origin for every additional route. Other cross-origin
+            redirects, HTTPS downgrades, and client-side cross-origin
+            navigations remain blocked. Reports use the resolved origin as their
+            target; human output also identifies the originally requested origin
+            when it changed.
           </p>
           <p>The two fixed CSS viewports are:</p>
           <ul>
@@ -330,16 +342,18 @@ export default function DocsPage() {
             do not enlarge the document remain valid.
           </p>
           <p>
-            This is a standalone rendered check, not another source-audit rule.
-            It produces no score or grade and does not change the 62-rule
-            catalog, ruleset, audit schema, or existing{" "}
-            <code>mobile-overflow-absent</code> advisory.
+            This is a rendered UI suite, not another source-audit rule.
+            Horizontal overflow is its first check, and more deterministic UI
+            checks can be added to the same command. The current check produces
+            no score or grade and does not change the 62-rule catalog, ruleset,
+            audit schema, or existing <code>mobile-overflow-absent</code>{" "}
+            advisory.
           </p>
           <h3>Use it in automation</h3>
           <div className="not-typeset mt-4">
             <CodeBlockCommand
               {...getCliCommands(
-                "--check-overflow https://preview.example.com --json"
+                "--check-ui https://preview.example.com --json"
               )}
             />
           </div>
@@ -357,11 +371,11 @@ export default function DocsPage() {
             language="bash"
           />
           <p>
-            Overflow mode performs GET navigations and executes the target
+            Rendered UI mode performs GET navigations and executes the target
             page&apos;s JavaScript in fresh isolated Chromium contexts. It reads
             no project source, invokes no package scripts, and saves no page
-            data. In its first release it is available only in the local CLI,
-            not through MCP, the GitHub Action, hosted API, or web scanner.
+            data. It is available only in the local CLI, not through MCP, the
+            GitHub Action, hosted API, or web scanner.
           </p>
         </section>
 
@@ -391,9 +405,9 @@ export default function DocsPage() {
             <code>--json</code> aliases cannot be combined with each other or
             with <code>--format</code>. <code>--apply</code> requires human
             output, and <code>--agent</code> requires <code>--apply</code>. In
-            overflow mode, only human or JSON output is available; source-audit
-            paths, score, category, prompt, agent, project-selection, and roast
-            options are rejected.
+            rendered UI mode, only human or JSON output is available;
+            source-audit paths, score, category, prompt, agent,
+            project-selection, and roast options are rejected.
           </p>
         </section>
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -8,7 +8,7 @@ a local install, a packed tarball, or npm through `npx`.
 ```text
 shadscan [path] [options]
 shadscan setup [path] --pre-commit [--dry-run | --yes]
-shadscan --check-overflow <url> [--route <path> ...]
+shadscan --check-ui <url> [--route <path> ...]
 ```
 
 - `path` selects the React project to scan and defaults to the current working
@@ -25,25 +25,36 @@ shadscan --check-overflow <url> [--route <path> ...]
 - `setup --pre-commit` plans a version-pinned score gate from the current
   complete assessed score. `--dry-run` never writes; `--yes` confirms an
   automatic safe plan without a prompt.
-- `--check-overflow <url>` is a standalone rendered check. It requires an
+- `--check-ui <url>` runs the standalone rendered UI suite. It requires an
   absolute HTTP or HTTPS URL for an already-running local or deployed app and
-  does not resolve or discover a project. The supplied URL is always checked;
-  repeatable `--route <path>` values add same-origin paths that begin with
-  exactly one `/`, up to ten pages in total. Routes cannot contain a query
-  string, fragment, or backslash.
-- The overflow check uses fixed CSS viewports of 320 × 820 (mobile) and 1440 ×
-  1000 (desktop), both at device scale factor 1. It fails on any
+  does not resolve or discover a project. Horizontal overflow is the suite's
+  first check; future deterministic rendered checks can use the same command.
+  The supplied URL is always checked; repeatable `--route <path>` values add
+  paths that begin with exactly one `/`, up to ten pages in total. Routes
+  cannot contain a query string, fragment, or backslash.
+- The horizontal-overflow check uses fixed CSS viewports of 320 × 820 (mobile)
+  and 1440 × 1000 (desktop), both at device scale factor 1. It fails on any
   document-level horizontal overflow or a horizontal scrollbar forced on the
   root or body. It does not add an audit rule, score, or grade and does not
   change the source audit, bundled rule count, ruleset, or audit schema.
+- The initial navigation may follow canonical server redirects. Every URL must
+  be credential-free HTTP(S). In addition to exact-origin redirects, the chain
+  may contain at most one anchored `www` change for a conventional two-label
+  apex host (or localhost) and at most one HTTP-to-HTTPS default-port upgrade.
+  Targets under multi-label public suffixes must use their canonical origin
+  directly. HTTPS downgrades, other host or port changes, project-subdomain
+  aliases, and client-side cross-origin navigations are rejected. Mobile and
+  desktop must resolve to the same origin. That resolved origin is pinned, and
+  every `--route` path is resolved against it.
 - The caller starts or deploys the target app. Shadscan does not run install,
-  dev, build, or start scripts for overflow mode. `--browser-executable <path>`
-  may select a Chromium-family executable explicitly.
-- Overflow mode accepts human or JSON output, `--route`,
+  dev, build, or start scripts for rendered UI mode.
+  `--browser-executable <path>` may select a Chromium-family executable
+  explicitly.
+- Rendered UI mode accepts human or JSON output, `--route`,
   `--browser-executable`, `--no-interactive`, and `--no-roast`. It rejects a
   non-default project path and source-audit-only score, category, prompt, agent,
   project-selection, listing, and positive-roast options. `--route` and
-  `--browser-executable` are invalid without `--check-overflow`.
+  `--browser-executable` are invalid without `--check-ui`.
 
 ## Output
 
@@ -54,11 +65,13 @@ shadscan --check-overflow <url> [--route <path> ...]
 - `--format json` and `--json` write one versioned JSON report to stdout.
 - `--format prompt` and `--prompt` write one deterministic agent handoff to
   stdout.
-- Overflow mode supports human output, `--format human`, `--format json`, and
-  `--json`. Its JSON output is a separate versioned `overflow-check` report,
-  not an audit report. It contains every requested page and viewport
-  measurement, bounded likely-culprit selectors for failures, and a summary,
-  but no score, grade, or rule result.
+- Rendered UI mode supports human output, `--format human`, `--format json`,
+  and `--json`. Its current JSON output is a separate versioned
+  `overflow-check` report, not an audit report. It contains every requested
+  page and viewport measurement, bounded likely-culprit selectors for failures,
+  and a summary, but no score, grade, or rule result. `target.origin` is the
+  resolved, pinned origin. Human output also identifies the originally
+  requested origin when a canonical redirect changed it.
 - A detected overflow writes the complete human or JSON report to stdout before
   exiting non-zero. An overflow operational failure leaves stdout empty and
   writes a stable human or versioned JSON error to stderr.
@@ -91,10 +104,11 @@ shadscan --check-overflow <url> [--route <path> ...]
   `--fail-under` was not satisfied.
 - Findings do not fail the process unless the caller supplies `--fail-under`.
 - Launching an agent never clears an existing score-threshold failure.
-- In overflow mode, `0` means every requested page fit both fixed viewports.
-  Detected overflow is a critical failure and exits `1`. Invalid arguments,
-  an unavailable browser or target, unsupported response, unstable page,
-  timeout, redirect-policy violation, and measurement failure also exit `1`.
+- In rendered UI mode, `0` currently means every requested page fit both fixed
+  viewports. Detected overflow is a critical failure and exits `1`. Invalid
+  arguments, an unavailable browser or target, unsupported response, unstable
+  page, timeout, redirect-policy violation, and measurement failure also exit
+  `1`.
 
 ## Stability
 
@@ -109,12 +123,12 @@ shadscan --check-overflow <url> [--route <path> ...]
 - The scanner itself does not send project source, findings, or environment
   variables over the network. An explicitly launched external agent may read
   and edit files, run commands, and send the generated prompt to its provider.
-- Overflow mode is an explicit network exception: it performs GET navigations
-  to the supplied target and same-origin routes, follows only same-origin
-  redirects, and executes the target's page JavaScript in fresh isolated
-  Chromium contexts. It reads no project source, invokes no package
-  scripts, persists no cookies between measurements, and saves no page data.
-  Query strings and fragments are redacted from reports.
+- Rendered UI mode is an explicit network exception: it performs GET
+  navigations to the supplied target and requested routes, follows only the
+  canonical server redirects defined above, and executes the target's page
+  JavaScript in fresh isolated Chromium contexts. It reads no project source,
+  invokes no package scripts, persists no cookies between measurements, and
+  saves no page data. Query strings and fragments are redacted from reports.
 - Agent discovery only trusts executables outside the project, validates their
   provider-specific `--version` output, passes argument arrays without building
   a user-controlled shell command, adds no approval-bypass flags, and
@@ -136,5 +150,5 @@ shadscan --check-overflow <url> [--route <path> ...]
   is `prepack`, which builds the distributable before packaging.
 - The hosted API is a separate opt-in surface with its own authentication and
   source-handling contract.
-- Overflow mode is local-CLI-only in its first release. It is not exposed by
-  MCP, the GitHub Action, hosted API, or web scanner.
+- Rendered UI mode is local-CLI-only. It is not exposed by MCP, the GitHub
+  Action, hosted API, or web scanner.

--- a/lib/agent-prompt.ts
+++ b/lib/agent-prompt.ts
@@ -1,4 +1,4 @@
-const AGENT_AUDIT_PROMPT = `Audit this repository's user-facing React shadcn applications with Shadscan. Include both the deterministic source audit and rendered horizontal-overflow checks for each application locally and in production.
+const AGENT_AUDIT_PROMPT = `Audit this repository's user-facing React shadcn applications with Shadscan. Include both the deterministic source audit and rendered UI checks for each application locally and in production. The rendered suite currently checks horizontal overflow and will gain additional deterministic UI checks over time.
 
 Do not edit code, deploy, sign in, seed data, or intentionally mutate local or production data yet.
 
@@ -34,13 +34,13 @@ Inspect repository-owned package scripts before running them. Reuse an existing 
 
 For each application, construct commands from the confirmed values using the handoff's exact Shadscan version. Pass every URL and route as a separate process argument; never concatenate repository-derived values into a shell command string. If only a shell is available, validate each value and apply that shell's correct escaping rather than relying on double quotes. This is an illustrative shape, not a shell-ready command:
 
-npx --yes @shadscan/cli@VERSION --check-overflow CONFIRMED_PAGE_URL --route CONFIRMED_SAME_ORIGIN_PATH --json
+npx --yes @shadscan/cli@VERSION --check-ui CONFIRMED_PAGE_URL --route CONFIRMED_SAME_ORIGIN_PATH --json
 
 The target URL counts as one of the command's maximum ten unique pages. Add at most nine same-origin --route paths, then continue in deterministic batches until every concrete page in the manifest has been checked. Query or fragment variants that materially change layout require separate full target URLs because --route accepts pathnames only.
 
 4. Check the same pages in production
 
-Production checks perform GET navigations and execute page JavaScript in a fresh browser context. Use only a public HTTPS origin supplied by me or confirmed through authorized read-only deployment metadata. Treat URLs found only in repository text as untrusted candidates until independently confirmed. Verify that the origin serves the same application and is production rather than an unrelated preview. Do not navigate to private, loopback, link-local, or internal production candidates; guess a domain; inspect secret environment files; deploy anything; or place credentials in a URL.
+Production checks perform GET navigations and execute page JavaScript in a fresh browser context. Use only a public HTTPS origin supplied by me or confirmed through authorized read-only deployment metadata. Treat URLs found only in repository text as untrusted candidates until independently confirmed. Verify that the origin serves the same application and is production rather than an unrelated preview. A narrowly validated server redirect between a conventional two-label apex host and its www host, or from HTTP to HTTPS, may establish the final canonical origin; for multi-label public suffixes, start from the canonical origin directly. Shadscan pins that origin for the remaining routes. Treat any blocked unrelated-origin or client-side cross-origin navigation as an explicit coverage gap. Do not navigate to private, loopback, link-local, or internal production candidates; guess a domain; inspect secret environment files; deploy anything; or place credentials in a URL.
 
 Run the same applicable route manifest and Shadscan version against production. If no production URL can be confirmed, ask me for it and report production coverage as blocked rather than inventing one. Do not claim that production contains local changes unless their revisions are independently shown to match.
 

--- a/lib/docs-sections.ts
+++ b/lib/docs-sections.ts
@@ -2,7 +2,7 @@ import type { DocsSection } from "@/components/docs-on-this-page";
 
 const DOCS_SECTIONS = [
   { href: "#usage", label: "Usage" },
-  { href: "#overflow-check", label: "Overflow check" },
+  { href: "#ui-check", label: "UI checks" },
   { href: "#options", label: "Options" },
   { href: "#agent-prompt", label: "Agent prompt" },
   { href: "#apply", label: "Apply with an agent" },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -114,11 +114,11 @@ pnpm exec shadscan --fail-under 80 --no-interactive --no-roast
 # Audit one category while investigating a focused area
 pnpm dlx @shadscan/cli --category accessibility
 
-# Check an already-running app for horizontal overflow
-pnpm dlx @shadscan/cli --check-overflow http://localhost:3000
+# Run rendered UI checks against an already-running app
+pnpm dlx @shadscan/cli --check-ui http://localhost:3000
 
 # Add same-origin routes to the target URL
-pnpm dlx @shadscan/cli --check-overflow http://localhost:3000 --route /dashboard --route /settings
+pnpm dlx @shadscan/cli --check-ui http://localhost:3000 --route /dashboard --route /settings
 ```
 
 Use `--format human`, `--format json`, or `--format prompt` when output selection
@@ -127,16 +127,24 @@ needs to be explicit.
 Pin an exact package version in CI; unqualified commands resolve to the latest
 stable release. Run `pnpm dlx @shadscan/cli --help` for every option.
 
-## Rendered Horizontal Overflow
+## Rendered UI Checks
 
-`--check-overflow <url>` is a focused critical gate for an already-running
-local or deployed app. It opens isolated Chromium pages at two fixed CSS
-viewports — mobile at 320 × 820 and desktop at 1440 × 1000 — and fails on any
-document-level horizontal overflow, including a one-pixel overflow or a
-horizontal scrollbar forced on the root or body. The target URL is always
-checked; repeat `--route <path>` to add same-origin pages, up to ten pages in
-total. Each route must begin with `/` and cannot contain a query string or
-fragment.
+`--check-ui <url>` is the home for deterministic checks that need a rendered
+page. Horizontal overflow is its first check. It opens an already-running local
+or deployed app in isolated Chromium pages at two fixed CSS viewports — mobile
+at 320 × 820 and desktop at 1440 × 1000 — and fails on any document-level
+horizontal overflow, including a one-pixel overflow or a horizontal scrollbar
+forced on the root or body. The target URL is always checked; repeat
+`--route <path>` to add pages, up to ten pages in total. Each route must begin
+with `/` and cannot contain a query string or fragment.
+
+The initial request may follow narrowly validated server-side canonical
+redirects between a conventional two-label apex host and its `www` host, and
+from HTTP to HTTPS. For multi-label public suffixes, pass the canonical origin
+directly. The resolved origin is then pinned for every additional route. Other cross-origin
+redirects, HTTPS downgrades, and client-side cross-origin navigations remain
+blocked. Reports use the resolved origin as their target; human output also
+identifies the originally requested origin when it changed.
 
 This is separate from the default static source audit. It does not add a rule,
 score, or grade, and the 62-rule catalog and existing
@@ -152,10 +160,10 @@ Chromium is not available, install the matching managed browser with:
 pnpm dlx playwright-core@1.61.1 install chromium
 ```
 
-The overflow check performs GET navigations and executes page JavaScript in
+Rendered UI checks perform GET navigations and execute page JavaScript in
 fresh isolated browser contexts. It reads no project source, invokes no package
-scripts, and saves no page data. In its first release it is available only in
-the local CLI, not through MCP, the GitHub Action, hosted API, or web scanner.
+scripts, and saves no page data. It is available only in the local CLI, not
+through MCP, the GitHub Action, hosted API, or web scanner.
 
 ## Agent Handoff
 
@@ -245,8 +253,8 @@ generic React applications.
 ## Privacy And Exit Status
 
 The default local scan is static and stays on your machine. The explicit
-`--check-overflow` mode navigates to the URL you provide under the separate
-rendered-check contract above.
+`--check-ui` mode navigates to the URL you provide under the separate rendered
+UI contract above.
 
 Findings return exit status `0` unless `--fail-under` is not satisfied.
 Discovery, audit, setup, and launched-agent failures return `1`. Use

--- a/packages/cli/scripts/smoke-package.mjs
+++ b/packages/cli/scripts/smoke-package.mjs
@@ -199,7 +199,8 @@ try {
   });
   assert.match(helpResult.stdout, /--apply/);
   assert.match(helpResult.stdout, /--agent <agent>/);
-  assert.match(helpResult.stdout, /--check-overflow <url>/);
+  assert.match(helpResult.stdout, /--check-ui <url>/);
+  assert.ok(!helpResult.stdout.includes("--check-overflow"));
   assert.match(helpResult.stdout, /--no-interactive/);
   assert.match(helpResult.stdout, /setup/);
 
@@ -286,7 +287,7 @@ try {
   });
   assert.match(invalidAgentResult.stderr, /--agent requires --apply/);
 
-  const invalidOverflowResult = await run(
+  const legacyOverflowAliasResult = await run(
     executable,
     ["--check-overflow", "not-a-url", "--json"],
     {
@@ -294,11 +295,11 @@ try {
       expectedExitCode: 1,
     }
   );
-  assert.equal(invalidOverflowResult.stdout, "");
-  assert.equal(
-    JSON.parse(invalidOverflowResult.stderr).error.code,
-    "INVALID_ARGUMENTS"
-  );
+  assert.equal(legacyOverflowAliasResult.stdout, "");
+  assert.deepEqual(JSON.parse(legacyOverflowAliasResult.stderr).error, {
+    code: "INVALID_ARGUMENTS",
+    message: "The overflow target must be an absolute HTTP or HTTPS URL.",
+  });
 
   const browserExecutable =
     getOptionValue("--browser-executable") ??
@@ -314,11 +315,7 @@ try {
     ];
     const fittingOverflowResult = await run(
       executable,
-      [
-        "--check-overflow",
-        `${overflowFixtureOrigin}/fits`,
-        ...browserArguments,
-      ],
+      ["--check-ui", `${overflowFixtureOrigin}/fits`, ...browserArguments],
       { cwd: consumerDirectory }
     );
     assert.equal(fittingOverflowResult.stderr, "");
@@ -335,11 +332,7 @@ try {
 
     const failingOverflowResult = await run(
       executable,
-      [
-        "--check-overflow",
-        `${overflowFixtureOrigin}/overflow`,
-        ...browserArguments,
-      ],
+      ["--check-ui", `${overflowFixtureOrigin}/overflow`, ...browserArguments],
       { cwd: consumerDirectory, expectedExitCode: 1 }
     );
     assert.equal(failingOverflowResult.stderr, "");

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -69,6 +69,7 @@ interface CliOptions {
   browserExecutable?: string;
   category?: AuditCategory;
   checkOverflow?: string;
+  checkUi?: string;
   failUnder?: number;
   format?: OutputFormat;
   interactive: boolean;
@@ -90,7 +91,7 @@ type OverflowBrowserRunner = (
   options: RunOverflowBrowserCheckOptions
 ) => Promise<OverflowBrowserCheckResult>;
 
-interface OverflowCheckRuntime {
+interface UiCheckRuntime {
   runBrowserCheck?: OverflowBrowserRunner;
 }
 
@@ -496,7 +497,10 @@ const validateScanActionOptions = (
   }
 };
 
-const validateOverflowModeOptions = ({
+const getUiCheckTarget = (options: CliOptions): string | undefined =>
+  options.checkUi ?? options.checkOverflow;
+
+const validateUiModeOptions = ({
   command,
   options,
   outputFormat,
@@ -509,7 +513,7 @@ const validateOverflowModeOptions = ({
 }): void => {
   if (projectPath !== ".") {
     throw new InvalidArgumentError(
-      "--check-overflow does not accept a project path."
+      "--check-ui does not accept a project path."
     );
   }
 
@@ -528,36 +532,34 @@ const validateOverflowModeOptions = ({
 
   if (incompatibleOption) {
     throw new InvalidArgumentError(
-      `--check-overflow cannot be used with ${incompatibleOption}.`
+      `--check-ui cannot be used with ${incompatibleOption}.`
     );
   }
 };
 
 const validateFocusedOptions = (options: CliOptions): void => {
-  if (options.checkOverflow !== undefined) {
+  if (getUiCheckTarget(options) !== undefined) {
     return;
   }
 
   if ((options.route?.length ?? 0) > 0) {
-    throw new InvalidArgumentError("--route requires --check-overflow.");
+    throw new InvalidArgumentError("--route requires --check-ui.");
   }
 
   if (options.browserExecutable !== undefined) {
-    throw new InvalidArgumentError(
-      "--browser-executable requires --check-overflow."
-    );
+    throw new InvalidArgumentError("--browser-executable requires --check-ui.");
   }
 };
 
 const rejectFocusedOptionsForSubcommand = (command: Command): void => {
   const rootOptions = command.parent?.opts<CliOptions>();
   if (
-    rootOptions?.checkOverflow !== undefined ||
+    (rootOptions && getUiCheckTarget(rootOptions) !== undefined) ||
     rootOptions?.browserExecutable !== undefined ||
     (rootOptions?.route?.length ?? 0) > 0
   ) {
     throw new InvalidArgumentError(
-      "--check-overflow and its related options cannot be used with subcommands."
+      "--check-ui and its related options cannot be used with subcommands."
     );
   }
 };
@@ -574,7 +576,7 @@ const getOutputTerminalCapabilities = () =>
     isTTY: process.stdout.isTTY === true,
   });
 
-const runOverflowCheckAction = async (
+const runUiCheckAction = async (
   {
     browserExecutable,
     outputFormat,
@@ -586,7 +588,7 @@ const runOverflowCheckAction = async (
     routes?: string[];
     target: string;
   },
-  runtime: OverflowCheckRuntime = {}
+  runtime: UiCheckRuntime = {}
 ): Promise<void> => {
   const resolvedTarget = resolveOverflowCheckTarget({ routes, target });
   let runBrowserCheck = runtime.runBrowserCheck;
@@ -613,7 +615,7 @@ const runOverflowCheckAction = async (
       durationMs: browserResult.durationMs,
       measurements: browserResult.measurements,
       target: {
-        origin: resolvedTarget.origin,
+        origin: browserResult.origin,
         pages: resolvedTarget.pages.map((page) => page.displayPath),
       },
     });
@@ -621,6 +623,7 @@ const runOverflowCheckAction = async (
       outputFormat === "json"
         ? `${JSON.stringify(report, null, 2)}\n`
         : renderOverflowCheckReport(report, {
+            requestedOrigin: resolvedTarget.origin,
             terminal: getOutputTerminalCapabilities(),
           });
 
@@ -738,24 +741,29 @@ const runProjectScanPhases = async ({
 const runScanAction = async (
   projectPath: string,
   options: CliOptions,
-  command: Command
+  command: Command,
+  runtime: UiCheckRuntime = {}
 ): Promise<void> => {
   validateFocusedOptions(options);
   const outputFormat = resolveOutputFormat(options);
 
-  if (options.checkOverflow !== undefined) {
-    validateOverflowModeOptions({
+  const uiCheckTarget = getUiCheckTarget(options);
+  if (uiCheckTarget !== undefined) {
+    validateUiModeOptions({
       command,
       options,
       outputFormat,
       projectPath,
     });
-    await runOverflowCheckAction({
-      browserExecutable: options.browserExecutable,
-      outputFormat,
-      routes: options.route,
-      target: options.checkOverflow,
-    });
+    await runUiCheckAction(
+      {
+        browserExecutable: options.browserExecutable,
+        outputFormat,
+        routes: options.route,
+        target: uiCheckTarget,
+      },
+      runtime
+    );
     return;
   }
 
@@ -907,7 +915,7 @@ const runSetupAction = async (
   );
 };
 
-const createProgram = (): Command => {
+const createProgram = (runtime: UiCheckRuntime = {}): Command => {
   const program = new Command();
 
   program
@@ -957,18 +965,26 @@ const createProgram = (): Command => {
       "Run only one audit category.",
       parseCategory
     )
-    .option(
-      "--check-overflow <url>",
-      "Check a running page for horizontal overflow at mobile and desktop widths."
+    .addOption(
+      new Option(
+        "--check-ui <url>",
+        "Run rendered UI checks at mobile and desktop widths."
+      ).conflicts("checkOverflow")
+    )
+    .addOption(
+      new Option(
+        "--check-overflow <url>",
+        "Legacy alias for --check-ui."
+      ).hideHelp()
     )
     .option(
       "--route <path>",
-      "Add a same-origin route to --check-overflow (repeatable).",
+      "Add a same-origin route to --check-ui (repeatable).",
       collectRoute
     )
     .option(
       "--browser-executable <path>",
-      "Use a specific Chromium executable for --check-overflow."
+      "Use a specific Chromium executable for --check-ui."
     )
     .option("--no-roast", "Use neutral human output.")
     .option("--roast", "Force roast copy in CI and JSON output.")
@@ -981,7 +997,11 @@ const createProgram = (): Command => {
       "--project <path>",
       "Scan one workspace package instead of pooling every application."
     )
-    .action(runScanAction);
+    .action(
+      async (projectPath: string, options: CliOptions, command: Command) => {
+        await runScanAction(projectPath, options, command, runtime);
+      }
+    );
 
   program
     .command("setup")
@@ -1047,6 +1067,6 @@ export {
   createProgram,
   resolveProjectPath,
   runCli,
-  runOverflowCheckAction,
+  runUiCheckAction,
   scoreFailsThreshold,
 };

--- a/packages/cli/src/overflow-check/browser.ts
+++ b/packages/cli/src/overflow-check/browser.ts
@@ -1,6 +1,7 @@
 import type {
   Browser,
   BrowserType,
+  CDPSession,
   Page,
   Request,
   Response,
@@ -19,6 +20,11 @@ import {
 } from "./contracts";
 import { OverflowCheckError } from "./error";
 import type { ResolvedOverflowPage } from "./options";
+import {
+  type CanonicalRedirectPolicy,
+  createCanonicalRedirectPolicy,
+  followCanonicalServerRedirect,
+} from "./redirect-policy";
 
 const DEFAULT_CHECK_TIMEOUT_MS = 60_000;
 const NAVIGATION_TIMEOUT_MS = 15_000;
@@ -54,6 +60,19 @@ interface OverflowBrowserCheckResult {
   browser: OverflowBrowserMetadata;
   durationMs: number;
   measurements: OverflowMeasurementInput[];
+  origin: string;
+}
+
+interface SettledOverflowMeasurement {
+  finalOrigin: string;
+  measurement: OverflowMeasurementInput;
+}
+
+interface CanonicalNavigationState {
+  canonicalRequestId: string | null;
+  crossOriginMainNavigation: boolean;
+  pinnedOrigin: string | null;
+  redirectPolicy: CanonicalRedirectPolicy;
 }
 
 interface LoadedPlaywright {
@@ -203,12 +222,148 @@ const isSameOrigin = (url: string, expectedOrigin: string): boolean => {
   }
 };
 
+const toNavigationHref = (value: string): string | null => {
+  try {
+    const url = new URL(value);
+    url.hash = "";
+    return url.href;
+  } catch {
+    return null;
+  }
+};
+
+const resolveInitialRedirectPolicy = (
+  response: Response,
+  requestedUrl: string
+): CanonicalRedirectPolicy | null => {
+  const requests: Request[] = [];
+  let request: Request | null = response.request();
+
+  while (request) {
+    requests.push(request);
+    request = request.redirectedFrom();
+  }
+
+  requests.reverse();
+  const firstRequest = requests[0];
+  if (
+    !firstRequest ||
+    toNavigationHref(firstRequest.url()) !== toNavigationHref(requestedUrl)
+  ) {
+    return null;
+  }
+
+  let policy = createCanonicalRedirectPolicy(requestedUrl);
+  if (!policy) {
+    return null;
+  }
+
+  for (const redirectedRequest of requests.slice(1)) {
+    policy = followCanonicalServerRedirect(policy, redirectedRequest.url());
+    if (!policy) {
+      return null;
+    }
+  }
+
+  return policy;
+};
+
 const isSuccessfulHtmlResponse = (response: Response): boolean => {
   const status = response.status();
   const contentType = response.headers()["content-type"] ?? "";
   return (
     status >= 200 && status < 300 && HTML_CONTENT_TYPE_PATTERN.test(contentType)
   );
+};
+
+const installMainFrameNavigationGuard = async ({
+  browserContext,
+  context,
+  page,
+  state,
+}: {
+  browserContext: Awaited<ReturnType<Browser["newContext"]>>;
+  context: MeasurementContext;
+  page: Page;
+  state: CanonicalNavigationState;
+}): Promise<CDPSession> => {
+  const session = await runBeforeDeadline(
+    browserContext.newCDPSession(page),
+    context
+  );
+  const { frameTree } = await runBeforeDeadline(
+    session.send("Page.getFrameTree"),
+    context
+  );
+  const mainFrameId = frameTree.frame.id;
+  const continueRequest = (requestId: string): void => {
+    session.send("Fetch.continueRequest", { requestId }).catch(() => undefined);
+  };
+  const failRequest = (requestId: string): void => {
+    session
+      .send("Fetch.failRequest", {
+        errorReason: "BlockedByClient",
+        requestId,
+      })
+      .catch(() => undefined);
+  };
+
+  session.on("Fetch.requestPaused", (event) => {
+    const isMainFrameNavigation =
+      event.resourceType === "Document" && event.frameId === mainFrameId;
+    if (!isMainFrameNavigation) {
+      continueRequest(event.requestId);
+      return;
+    }
+
+    const allowedOrigin =
+      state.pinnedOrigin ?? state.redirectPolicy.resolvedOrigin;
+    if (isSameOrigin(event.request.url, allowedOrigin)) {
+      if (state.pinnedOrigin === null) {
+        const startsCanonicalChain = state.canonicalRequestId === null;
+        const continuesCanonicalChain =
+          event.redirectedRequestId === state.canonicalRequestId;
+
+        if (startsCanonicalChain || continuesCanonicalChain) {
+          state.canonicalRequestId = event.requestId;
+        } else {
+          state.pinnedOrigin = allowedOrigin;
+        }
+      }
+      continueRequest(event.requestId);
+      return;
+    }
+
+    const continuesCanonicalChain =
+      state.canonicalRequestId !== null &&
+      event.redirectedRequestId === state.canonicalRequestId;
+    const nextPolicy =
+      state.pinnedOrigin === null && continuesCanonicalChain
+        ? followCanonicalServerRedirect(state.redirectPolicy, event.request.url)
+        : null;
+    if (nextPolicy) {
+      state.canonicalRequestId = event.requestId;
+      state.redirectPolicy = nextPolicy;
+      continueRequest(event.requestId);
+      return;
+    }
+
+    state.crossOriginMainNavigation = true;
+    failRequest(event.requestId);
+  });
+  await runBeforeDeadline(
+    session.send("Fetch.enable", {
+      patterns: [
+        {
+          requestStage: "Request",
+          resourceType: "Document",
+          urlPattern: "*",
+        },
+      ],
+    }),
+    context
+  );
+  return session;
 };
 
 const hasOnlySameOriginRedirects = (
@@ -316,14 +471,16 @@ const toMeasurementInput = ({
 const navigateAndMeasure = async ({
   browser,
   context,
+  expectedFinalOrigin,
   page: targetPage,
   viewport,
 }: {
   browser: Browser;
   context: MeasurementContext;
+  expectedFinalOrigin?: string;
   page: OverflowBrowserPage;
   viewport: OverflowViewport;
-}): Promise<OverflowMeasurementInput> => {
+}): Promise<SettledOverflowMeasurement> => {
   const browserContext = await runBeforeDeadline(
     browser.newContext({
       acceptDownloads: false,
@@ -339,22 +496,38 @@ const navigateAndMeasure = async ({
   try {
     const page = await runBeforeDeadline(browserContext.newPage(), context);
     const displayPath = sanitizeDisplayPath(targetPage.displayPath);
-    let crossOriginMainNavigation = false;
+    let initialNavigationResponse: Response | null = null;
     let latestMainFrameResponse: Response | null = null;
+    const initialRedirectPolicy = createCanonicalRedirectPolicy(
+      targetPage.requestedUrl
+    );
+    if (!initialRedirectPolicy) {
+      throw createCheckError(
+        "OVERFLOW_TARGET_UNAVAILABLE",
+        `The target page ${displayPath} could not be loaded.`
+      );
+    }
+    if (
+      expectedFinalOrigin &&
+      initialRedirectPolicy.resolvedOrigin !== expectedFinalOrigin
+    ) {
+      throw createCheckError(
+        "OVERFLOW_TARGET_UNAVAILABLE",
+        `The target page ${displayPath} did not resolve to the expected canonical origin.`
+      );
+    }
+    const navigationState: CanonicalNavigationState = {
+      canonicalRequestId: null,
+      crossOriginMainNavigation: false,
+      pinnedOrigin: expectedFinalOrigin ?? null,
+      redirectPolicy: initialRedirectPolicy,
+    };
     await runBeforeDeadline(
-      page.route("**/*", async (route) => {
-        const request = route.request();
-        if (
-          request.isNavigationRequest() &&
-          request.frame() === page.mainFrame() &&
-          !isSameOrigin(request.url(), context.origin)
-        ) {
-          crossOriginMainNavigation = true;
-          await route.abort("blockedbyclient");
-          return;
-        }
-
-        await route.continue();
+      installMainFrameNavigationGuard({
+        browserContext,
+        context,
+        page,
+        state: navigationState,
       }),
       context
     );
@@ -374,8 +547,9 @@ const navigateAndMeasure = async ({
     });
     const throwIfCrossOriginNavigation = (): void => {
       if (
-        crossOriginMainNavigation ||
-        !isSameOrigin(page.url(), context.origin)
+        navigationState.crossOriginMainNavigation ||
+        (navigationState.pinnedOrigin !== null &&
+          !isSameOrigin(page.url(), navigationState.pinnedOrigin))
       ) {
         throw createCheckError(
           "OVERFLOW_TARGET_UNAVAILABLE",
@@ -386,16 +560,56 @@ const navigateAndMeasure = async ({
     const getValidatedMainFrameResponse = (): Response => {
       throwIfCrossOriginNavigation();
       const settledResponse = latestMainFrameResponse;
-      const responseIsValid =
-        settledResponse !== null &&
-        isSuccessfulHtmlResponse(settledResponse) &&
-        hasOnlySameOriginRedirects(settledResponse, context.origin);
-      if (!responseIsValid) {
+      if (!(settledResponse && isSuccessfulHtmlResponse(settledResponse))) {
         throw createCheckError(
           "OVERFLOW_TARGET_UNAVAILABLE",
           `The target page ${displayPath} did not return same-origin HTML with a successful status.`
         );
       }
+
+      if (navigationState.pinnedOrigin === null) {
+        const settledPolicy = resolveInitialRedirectPolicy(
+          settledResponse,
+          targetPage.requestedUrl
+        );
+        const finalOrigin = settledPolicy?.resolvedOrigin;
+        const originIsExpected =
+          expectedFinalOrigin === undefined ||
+          finalOrigin === expectedFinalOrigin;
+        if (
+          !(
+            settledPolicy &&
+            finalOrigin &&
+            originIsExpected &&
+            finalOrigin === navigationState.redirectPolicy.resolvedOrigin &&
+            isSameOrigin(page.url(), finalOrigin)
+          )
+        ) {
+          throw createCheckError(
+            "OVERFLOW_TARGET_UNAVAILABLE",
+            `The target page ${displayPath} did not resolve to the expected canonical origin.`
+          );
+        }
+
+        navigationState.redirectPolicy = settledPolicy;
+        navigationState.pinnedOrigin = finalOrigin;
+        initialNavigationResponse = settledResponse;
+        return settledResponse;
+      }
+
+      if (
+        settledResponse !== initialNavigationResponse &&
+        !hasOnlySameOriginRedirects(
+          settledResponse,
+          navigationState.pinnedOrigin
+        )
+      ) {
+        throw createCheckError(
+          "OVERFLOW_TARGET_UNAVAILABLE",
+          `The target page ${displayPath} did not return same-origin HTML with a successful status.`
+        );
+      }
+
       return settledResponse;
     };
     const navigationTimeout = Math.min(
@@ -430,7 +644,12 @@ const navigateAndMeasure = async ({
     }
     getValidatedMainFrameResponse();
 
-    await waitForPageReadiness(page, context);
+    try {
+      await waitForPageReadiness(page, context);
+    } catch (error) {
+      throwIfCrossOriginNavigation();
+      throw error;
+    }
     getValidatedMainFrameResponse();
     let browserMeasurement: BrowserOverflowMeasurement;
     try {
@@ -448,13 +667,23 @@ const navigateAndMeasure = async ({
     }
     const finalResponse = getValidatedMainFrameResponse();
 
-    return toMeasurementInput({
-      browserMeasurement,
-      finalPath: sanitizeReportPath(page.url()),
-      httpStatus: finalResponse.status(),
-      reportPath: targetPage.displayPath,
-      viewport,
-    });
+    if (!navigationState.pinnedOrigin) {
+      throw createCheckError(
+        "OVERFLOW_CHECK_FAILED",
+        "The browser could not resolve the measured page origin."
+      );
+    }
+
+    return {
+      finalOrigin: navigationState.pinnedOrigin,
+      measurement: toMeasurementInput({
+        browserMeasurement,
+        finalPath: sanitizeReportPath(page.url()),
+        httpStatus: finalResponse.status(),
+        reportPath: targetPage.displayPath,
+        viewport,
+      }),
+    };
   } finally {
     await Promise.allSettled(unexpectedPageClosures);
     await browserContext.close().catch(() => undefined);
@@ -512,6 +741,73 @@ const launchBrowser = async (
   );
 };
 
+const measurePageAtViewports = async ({
+  browser,
+  context,
+  expectedFinalOrigin,
+  page,
+}: {
+  browser: Browser;
+  context: MeasurementContext;
+  expectedFinalOrigin?: string;
+  page: OverflowBrowserPage;
+}): Promise<SettledOverflowMeasurement[]> => {
+  const settledMeasurements = await Promise.allSettled(
+    OVERFLOW_VIEWPORTS.map((viewport) =>
+      navigateAndMeasure({
+        browser,
+        context,
+        expectedFinalOrigin,
+        page,
+        viewport,
+      })
+    )
+  );
+  const rejectedMeasurement = settledMeasurements.find(
+    (result) => result.status === "rejected"
+  );
+
+  if (rejectedMeasurement?.status === "rejected") {
+    throw rejectedMeasurement.reason;
+  }
+
+  const measurements: SettledOverflowMeasurement[] = [];
+  for (const result of settledMeasurements) {
+    if (result.status === "fulfilled") {
+      measurements.push(result.value);
+    }
+  }
+  return measurements;
+};
+
+const getSharedFinalOrigin = (
+  measurements: readonly SettledOverflowMeasurement[]
+): string => {
+  const origins = new Set(
+    measurements.map((measurement) => measurement.finalOrigin)
+  );
+  const [origin] = origins;
+  if (origins.size !== 1 || !origin) {
+    throw createCheckError(
+      "OVERFLOW_TARGET_UNAVAILABLE",
+      "The target pages did not resolve to one canonical origin."
+    );
+  }
+  return origin;
+};
+
+const rebasePageToOrigin = (
+  page: OverflowBrowserPage,
+  origin: string
+): OverflowBrowserPage => {
+  const requestedUrl = new URL(page.requestedUrl);
+  const relativeUrl = `${requestedUrl.pathname}${requestedUrl.search}${requestedUrl.hash}`;
+  return {
+    ...page,
+    requestedUrl: new URL(relativeUrl, `${origin}/`).href,
+  };
+};
+
 const runOverflowBrowserCheck = async (
   {
     browserExecutable,
@@ -555,34 +851,37 @@ const runOverflowBrowserCheck = async (
 
   try {
     try {
+      const [firstPage, ...remainingPages] = pages;
+      if (!firstPage) {
+        throw createCheckError(
+          "OVERFLOW_CHECK_FAILED",
+          "The browser received no pages to measure."
+        );
+      }
       const measurements: OverflowMeasurementInput[] = [];
+      const firstPageMeasurements = await measurePageAtViewports({
+        browser: launchedBrowser.browser,
+        context,
+        page: firstPage,
+      });
+      const resolvedOrigin = getSharedFinalOrigin(firstPageMeasurements);
+      measurements.push(
+        ...firstPageMeasurements.map((result) => result.measurement)
+      );
 
-      for (const targetPage of pages) {
+      for (const targetPage of remainingPages) {
         throwIfInterrupted(signal);
         throwIfTimedOut(deadline, dependencies);
-        const settledMeasurements = await Promise.allSettled(
-          OVERFLOW_VIEWPORTS.map((viewport) =>
-            navigateAndMeasure({
-              browser: launchedBrowser.browser,
-              context,
-              page: targetPage,
-              viewport,
-            })
-          )
+        const routeMeasurements = await measurePageAtViewports({
+          browser: launchedBrowser.browser,
+          context,
+          expectedFinalOrigin: resolvedOrigin,
+          page: rebasePageToOrigin(targetPage, resolvedOrigin),
+        });
+        getSharedFinalOrigin(routeMeasurements);
+        measurements.push(
+          ...routeMeasurements.map((result) => result.measurement)
         );
-        const rejectedMeasurement = settledMeasurements.find(
-          (result) => result.status === "rejected"
-        );
-
-        if (rejectedMeasurement?.status === "rejected") {
-          throw rejectedMeasurement.reason;
-        }
-
-        for (const result of settledMeasurements) {
-          if (result.status === "fulfilled") {
-            measurements.push(result.value);
-          }
-        }
       }
 
       return {
@@ -592,6 +891,7 @@ const runOverflowBrowserCheck = async (
         },
         durationMs: Math.max(0, dependencies.now() - startedAt),
         measurements,
+        origin: resolvedOrigin,
       };
     } catch (error) {
       if (error instanceof OverflowCheckError) {

--- a/packages/cli/src/overflow-check/redirect-policy.ts
+++ b/packages/cli/src/overflow-check/redirect-policy.ts
@@ -1,0 +1,110 @@
+import { isIP } from "node:net";
+
+interface CanonicalRedirectPolicy {
+  readonly hostnameAliasUsed: boolean;
+  readonly originalOrigin: string;
+  readonly protocolUpgradeUsed: boolean;
+  readonly resolvedOrigin: string;
+}
+
+const parseHttpUrl = (value: string): URL | null => {
+  try {
+    const url = new URL(value);
+    const isHttp = url.protocol === "http:" || url.protocol === "https:";
+    const hasCredentials = url.username !== "" || url.password !== "";
+
+    return isHttp && !hasCredentials ? url : null;
+  } catch {
+    return null;
+  }
+};
+
+const createCanonicalRedirectPolicy = (
+  initialUrl: string
+): CanonicalRedirectPolicy | null => {
+  const parsedUrl = parseHttpUrl(initialUrl);
+
+  if (!parsedUrl) {
+    return null;
+  }
+
+  return {
+    hostnameAliasUsed: false,
+    originalOrigin: parsedUrl.origin,
+    protocolUpgradeUsed: false,
+    resolvedOrigin: parsedUrl.origin,
+  };
+};
+
+const getHostnameAlias = (hostname: string): string | null => {
+  const unwrappedHostname =
+    hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname;
+
+  if (isIP(unwrappedHostname) !== 0 || hostname.startsWith("www.www.")) {
+    return null;
+  }
+
+  const apexHostname = hostname.startsWith("www.")
+    ? hostname.slice(4)
+    : hostname;
+  const apexLabels = apexHostname.split(".");
+  const hasConservativeApexShape =
+    apexHostname === "localhost" ||
+    (apexLabels.length === 2 && apexLabels.every(Boolean));
+  if (!hasConservativeApexShape) {
+    return null;
+  }
+
+  return hostname.startsWith("www.") ? apexHostname : `www.${apexHostname}`;
+};
+
+const followCanonicalServerRedirect = (
+  policy: CanonicalRedirectPolicy,
+  nextUrl: string
+): CanonicalRedirectPolicy | null => {
+  const parsedUrl = parseHttpUrl(nextUrl);
+
+  if (!parsedUrl) {
+    return null;
+  }
+
+  if (parsedUrl.origin === policy.resolvedOrigin) {
+    return policy;
+  }
+
+  const currentUrl = new URL(policy.resolvedOrigin);
+  const originalUrl = new URL(policy.originalOrigin);
+  const hostnameChanges = parsedUrl.hostname !== currentUrl.hostname;
+  const protocolChanges = parsedUrl.protocol !== currentUrl.protocol;
+  const isAnchoredHostnameAlias =
+    !policy.hostnameAliasUsed &&
+    currentUrl.hostname === originalUrl.hostname &&
+    parsedUrl.hostname === getHostnameAlias(originalUrl.hostname);
+  const isDefaultPortProtocolUpgrade =
+    !policy.protocolUpgradeUsed &&
+    currentUrl.protocol === "http:" &&
+    parsedUrl.protocol === "https:" &&
+    currentUrl.port === "" &&
+    parsedUrl.port === "";
+  const hostnameIsAllowed = !hostnameChanges || isAnchoredHostnameAlias;
+  const protocolIsAllowed = !protocolChanges || isDefaultPortProtocolUpgrade;
+  const portIsAllowed = protocolChanges
+    ? isDefaultPortProtocolUpgrade
+    : parsedUrl.port === currentUrl.port;
+
+  if (!(hostnameIsAllowed && protocolIsAllowed && portIsAllowed)) {
+    return null;
+  }
+
+  return {
+    ...policy,
+    hostnameAliasUsed: policy.hostnameAliasUsed || hostnameChanges,
+    protocolUpgradeUsed: policy.protocolUpgradeUsed || protocolChanges,
+    resolvedOrigin: parsedUrl.origin,
+  };
+};
+
+export type { CanonicalRedirectPolicy };
+export { createCanonicalRedirectPolicy, followCanonicalServerRedirect };

--- a/packages/cli/src/overflow-check/render-human.ts
+++ b/packages/cli/src/overflow-check/render-human.ts
@@ -8,6 +8,7 @@ import type {
 } from "./contracts";
 
 interface RenderOverflowCheckReportOptions {
+  requestedOrigin?: string;
   terminal: TerminalCapabilities;
 }
 
@@ -66,15 +67,25 @@ const renderOverflowCheckReport = (
       ? colors.green(colors.bold("PASS"))
       : colors.red(colors.bold("CRITICAL FAIL"));
   const lines = [
-    colors.bold("shadscan overflow check"),
+    colors.bold("shadscan UI check"),
     "",
     status,
     `Target: ${sanitizeTerminalText(report.target.origin)}`,
+  ];
+  if (
+    options.requestedOrigin &&
+    options.requestedOrigin !== report.target.origin
+  ) {
+    lines.push(
+      `Canonical redirect: ${sanitizeTerminalText(options.requestedOrigin)} -> ${sanitizeTerminalText(report.target.origin)}`
+    );
+  }
+  lines.push(
     `Viewports: ${report.viewports
       .map((viewport) => renderViewport(viewport, options.terminal))
       .join(", ")}`,
-    `Pages: ${report.target.pages.map(sanitizeTerminalText).join(", ")}`,
-  ];
+    `Pages: ${report.target.pages.map(sanitizeTerminalText).join(", ")}`
+  );
 
   if (report.status === "pass") {
     lines.push(

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -10,7 +10,7 @@ import {
   createProgram,
   resolveProjectPath,
   runCli,
-  runOverflowCheckAction,
+  runUiCheckAction,
   scoreFailsThreshold,
 } from "../src/cli";
 import { normalizeCliFailure } from "../src/cli-error";
@@ -136,11 +136,16 @@ describe("CLI contract", () => {
 
   it("documents interactive apply and setup entry points", () => {
     const program = createProgram();
+    const help = program.helpInformation();
 
-    expect(program.helpInformation()).toContain("--apply");
-    expect(program.helpInformation()).toContain("--agent <agent>");
-    expect(program.helpInformation()).toContain("--check-overflow <url>");
-    expect(program.helpInformation()).toContain("--no-interactive");
+    expect(help).toContain("--apply");
+    expect(help).toContain("--agent <agent>");
+    expect(help).toContain("--check-ui <url>");
+    expect(help).not.toContain("--check-overflow");
+    expect(help).toContain("Add a same-origin route to --check-ui");
+    expect(help).toContain("--browser-executable <path>");
+    expect(help).toContain("--check-ui.");
+    expect(help).toContain("--no-interactive");
     expect(program.commands.map((command) => command.name())).toContain(
       "setup"
     );
@@ -174,7 +179,7 @@ describe("CLI contract", () => {
     }
   });
 
-  it("renders focused overflow JSON and exits on a completed finding", async () => {
+  it("renders focused UI-check JSON and exits on a completed finding", async () => {
     let stdout = "";
     const write = vi
       .spyOn(process.stdout, "write")
@@ -219,10 +224,11 @@ describe("CLI contract", () => {
           } as const,
         },
       ],
+      origin: "http://www.example.test",
     }));
 
     try {
-      await runOverflowCheckAction(
+      await runUiCheckAction(
         {
           outputFormat: "json",
           target: "http://127.0.0.1:3000",
@@ -239,20 +245,155 @@ describe("CLI contract", () => {
       schemaVersion: 1,
       status: "fail",
       summary: { failed: 1, maximumOverflowPx: 1, measurements: 2 },
+      target: { origin: "http://www.example.test" },
     });
     expect(process.exitCode).toBe(1);
   });
 
-  it("rejects focused overflow-only options during static scans", async () => {
+  it("uses --check-ui as the primary rendered UI command", async () => {
+    await expect(
+      captureOutput([
+        "--check-ui",
+        "http://127.0.0.1:3000",
+        "--route",
+        "/dashboard",
+        "--browser-executable",
+        "/tmp/chromium",
+        "--category",
+        "forms",
+      ])
+    ).rejects.toThrow("--check-ui cannot be used with --category.");
+  });
+
+  it.each([
+    "--check-ui",
+    "--check-overflow",
+  ])("forwards routes and browser selection through %s", async (uiFlag) => {
+    const runBrowserCheck = vi.fn(async () => ({
+      browser: { name: "chromium", version: "123" },
+      durationMs: 12,
+      measurements: ["/", "/dashboard"].flatMap((page) => [
+        {
+          clientWidth: 320,
+          finalPath: page,
+          forcedScrollbar: false,
+          httpStatus: 200,
+          page,
+          scrollWidth: 320,
+          viewport: { height: 820, name: "mobile", width: 320 } as const,
+        },
+        {
+          clientWidth: 1440,
+          finalPath: page,
+          forcedScrollbar: false,
+          httpStatus: 200,
+          page,
+          scrollWidth: 1440,
+          viewport: {
+            height: 1000,
+            name: "desktop",
+            width: 1440,
+          } as const,
+        },
+      ]),
+      origin: "http://127.0.0.1:3000",
+    }));
+    const program = createProgram({ runBrowserCheck });
+    const write = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    try {
+      await program.parseAsync([
+        "node",
+        "shadscan",
+        uiFlag,
+        "http://127.0.0.1:3000",
+        "--route",
+        "/dashboard",
+        "--browser-executable",
+        "/tmp/chromium",
+        "--json",
+      ]);
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(runBrowserCheck).toHaveBeenCalledWith(
+      expect.objectContaining({
+        browserExecutable: "/tmp/chromium",
+        origin: "http://127.0.0.1:3000",
+        pages: [
+          {
+            displayPath: "/",
+            requestedUrl: "http://127.0.0.1:3000/",
+          },
+          {
+            displayPath: "/dashboard",
+            requestedUrl: "http://127.0.0.1:3000/dashboard",
+          },
+        ],
+        signal: expect.any(AbortSignal),
+      })
+    );
+  });
+
+  it.each([
+    ["--check-ui", "--check-overflow"],
+    ["--check-overflow", "--check-ui"],
+  ])("rejects %s together with %s", async (firstFlag, secondFlag) => {
+    const program = createProgram().exitOverride();
+    program.configureOutput({ writeErr: () => undefined });
+
+    await expect(
+      program.parseAsync([
+        "node",
+        "shadscan",
+        firstFlag,
+        "http://127.0.0.1:3000",
+        secondFlag,
+        "http://127.0.0.1:3000",
+      ])
+    ).rejects.toMatchObject({ code: "commander.conflictingOption" });
+  });
+
+  it("keeps stderr clean when JSON mode rejects both UI flags", async () => {
+    const writeError = vi.spyOn(process.stderr, "write");
+
+    let failure: unknown;
+    try {
+      await runCli([
+        "node",
+        "shadscan",
+        "--check-ui",
+        "http://127.0.0.1:3000",
+        "--check-overflow",
+        "http://127.0.0.1:3000",
+        "--json",
+      ]);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(writeError).not.toHaveBeenCalled();
+    expect(normalizeCliFailure(failure)).toMatchObject({
+      code: "INVALID_ARGUMENTS",
+      message: expect.stringContaining(
+        "option '--check-ui <url>' cannot be used with option '--check-overflow <url>'"
+      ),
+    });
+  });
+
+  it("rejects rendered UI-only options during static scans", async () => {
     await expect(captureOutput(["--route", "/dashboard"])).rejects.toThrow(
-      "--route requires --check-overflow."
+      "--route requires --check-ui."
     );
     await expect(
       captureOutput(["--browser-executable", "/tmp/chromium"])
-    ).rejects.toThrow("--browser-executable requires --check-overflow.");
+    ).rejects.toThrow("--browser-executable requires --check-ui.");
   });
 
-  it("rejects static scan controls in focused overflow mode before launch", async () => {
+  it("keeps the legacy alias compatible while rejecting static scan controls", async () => {
     const conflicts = [
       { arguments: ["--category", "forms"], option: "--category" },
       { arguments: ["--fail-under", "90"], option: "--fail-under" },
@@ -269,15 +410,17 @@ describe("CLI contract", () => {
         captureOutput([
           "--check-overflow",
           "http://127.0.0.1:3000",
+          "--route",
+          "/dashboard",
+          "--browser-executable",
+          "/tmp/chromium",
           ...conflict.arguments,
         ])
-      ).rejects.toThrow(
-        `--check-overflow cannot be used with ${conflict.option}.`
-      );
+      ).rejects.toThrow(`--check-ui cannot be used with ${conflict.option}.`);
     }
   });
 
-  it("does not let focused overflow flags leak into subcommands", async () => {
+  it("does not let rendered UI flags leak into subcommands", async () => {
     await expect(
       captureOutput([
         "--check-overflow",
@@ -287,18 +430,18 @@ describe("CLI contract", () => {
         "--dry-run",
       ])
     ).rejects.toThrow(
-      "--check-overflow and its related options cannot be used with subcommands."
+      "--check-ui and its related options cannot be used with subcommands."
     );
   });
 
-  it("rejects a project path in focused overflow mode", async () => {
+  it("rejects a project path in rendered UI mode", async () => {
     await expect(
       captureOutput([
         "some-project",
         "--check-overflow",
         "http://127.0.0.1:3000",
       ])
-    ).rejects.toThrow("--check-overflow does not accept a project path.");
+    ).rejects.toThrow("--check-ui does not accept a project path.");
   });
 
   it("renders a deterministic score bar when stdout is not a TTY", async () => {

--- a/packages/cli/test/overflow-browser.test.ts
+++ b/packages/cli/test/overflow-browser.test.ts
@@ -3,9 +3,9 @@ import type {
   BrowserContext,
   BrowserContextOptions,
   BrowserType,
+  CDPSession,
   Page,
   Response,
-  Route,
 } from "playwright-core";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -26,6 +26,14 @@ interface BrowserFixture {
   newContext: ReturnType<typeof vi.fn>;
 }
 
+interface MockRequestPausedEvent {
+  frameId: string;
+  redirectedRequestId?: string;
+  request: { url: string };
+  requestId: string;
+  resourceType: "Document";
+}
+
 const createBrowserFixture = ({
   crossOriginNavigation = false,
   failManagedLaunch = false,
@@ -37,21 +45,48 @@ const createBrowserFixture = ({
 } = {}): BrowserFixture => {
   const closeBrowser = vi.fn(() => Promise.resolve(undefined));
   const closeContexts: ReturnType<typeof vi.fn>[] = [];
-  const abortRequest = vi.fn(() => Promise.resolve(undefined));
-  const response = {
-    headers: () => ({ "content-type": "text/html; charset=utf-8" }),
-    request: () => ({
-      redirectedFrom: () => null,
-      url: () => `${TARGET_ORIGIN}/fits?token=private#account`,
-    }),
-    status: () => 200,
-  } as unknown as Response;
+  const abortRequest = vi.fn((_parameters?: unknown) =>
+    Promise.resolve(undefined)
+  );
 
   const newContext = vi.fn((options: BrowserContextOptions) => {
     const clientWidth = options.viewport?.width ?? 0;
     const closeContext = vi.fn(() => Promise.resolve(undefined));
     const mainFrame = {};
-    let routeHandler: ((route: Route) => Promise<unknown>) | undefined;
+    const mainFrameId = "main-frame";
+    let currentUrl = `${TARGET_ORIGIN}/`;
+    let requestPausedHandler:
+      | ((event: MockRequestPausedEvent) => void)
+      | undefined;
+    const sendCdpCommand = vi.fn(
+      (method: string, parameters?: { requestId?: string }) => {
+        if (method === "Page.getFrameTree") {
+          return Promise.resolve({ frameTree: { frame: { id: mainFrameId } } });
+        }
+        if (method === "Fetch.failRequest") {
+          return abortRequest(parameters);
+        }
+        return Promise.resolve({});
+      }
+    );
+    const cdpSession = {
+      on: vi.fn(
+        (event: string, handler: (request: MockRequestPausedEvent) => void) => {
+          if (event === "Fetch.requestPaused") {
+            requestPausedHandler = handler;
+          }
+        }
+      ),
+      send: sendCdpCommand,
+    } as unknown as CDPSession;
+    const response = {
+      headers: () => ({ "content-type": "text/html; charset=utf-8" }),
+      request: () => ({
+        redirectedFrom: () => null,
+        url: () => currentUrl,
+      }),
+      status: () => 200,
+    } as unknown as Response;
     closeContexts.push(closeContext);
     const page = {
       evaluate: vi.fn((pageFunction: unknown) => {
@@ -79,32 +114,31 @@ const createBrowserFixture = ({
           scrollWidth: clientWidth,
         });
       }),
-      goto: vi.fn(async () => {
-        if (crossOriginNavigation && routeHandler) {
-          await routeHandler({
-            abort: abortRequest,
-            continue: vi.fn(() => Promise.resolve(undefined)),
-            request: () => ({
-              frame: () => mainFrame,
-              isNavigationRequest: () => true,
-              url: () => "https://external.example/private",
-            }),
-          } as unknown as Route);
+      goto: vi.fn((requestedUrl: string) => {
+        currentUrl = requestedUrl;
+        requestPausedHandler?.({
+          frameId: mainFrameId,
+          request: { url: requestedUrl },
+          requestId: "initial-navigation",
+          resourceType: "Document",
+        });
+        if (crossOriginNavigation) {
+          requestPausedHandler?.({
+            frameId: mainFrameId,
+            request: { url: "https://external.example/private" },
+            requestId: "client-navigation",
+            resourceType: "Document",
+          });
         }
-        return response;
+        return Promise.resolve(response);
       }),
       mainFrame: () => mainFrame,
       on: vi.fn(),
-      route: vi.fn(
-        (_pattern: string, handler: (route: Route) => Promise<unknown>) => {
-          routeHandler = handler;
-          return Promise.resolve(undefined);
-        }
-      ),
-      url: () => `${TARGET_ORIGIN}/fits?token=private#account`,
+      url: () => currentUrl,
     } as unknown as Page;
     const browserContext = {
       close: closeContext,
+      newCDPSession: vi.fn(() => Promise.resolve(cdpSession)),
       newPage: vi.fn(() => Promise.resolve(page)),
       on: vi.fn(),
     } as unknown as BrowserContext;

--- a/packages/cli/test/overflow-check-core.test.ts
+++ b/packages/cli/test/overflow-check-core.test.ts
@@ -336,7 +336,7 @@ describe("renderOverflowCheckReport", () => {
       terminal: PLAIN_TERMINAL,
     });
 
-    expect(output).toContain("shadscan overflow check");
+    expect(output).toContain("shadscan UI check");
     expect(output).toContain("CRITICAL FAIL");
     expect(output).toContain("mobile 320x820");
     expect(output).toContain("Likely culprit: #wide [31m (1px)");
@@ -355,5 +355,22 @@ describe("renderOverflowCheckReport", () => {
       "No horizontal overflow detected across 2 measurements."
     );
     expect(output).not.toContain("Remediation:");
+  });
+
+  it("shows a canonical server redirect in human output", () => {
+    const report = evaluateOverflowCheck({
+      durationMs: 1,
+      measurements: createMeasurementMatrix(),
+      target: { origin: "https://www.example.com", pages: ["/"] },
+    });
+    const output = renderOverflowCheckReport(report, {
+      requestedOrigin: "https://example.com",
+      terminal: PLAIN_TERMINAL,
+    });
+
+    expect(output).toContain("Target: https://www.example.com");
+    expect(output).toContain(
+      "Canonical redirect: https://example.com -> https://www.example.com"
+    );
   });
 });

--- a/packages/cli/test/overflow-redirect-policy.test.ts
+++ b/packages/cli/test/overflow-redirect-policy.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import {
+  createCanonicalRedirectPolicy,
+  followCanonicalServerRedirect,
+} from "../src/overflow-check/redirect-policy";
+
+describe("canonical redirect policy", () => {
+  it("allows redirects that stay on the requested origin", () => {
+    const policy = createCanonicalRedirectPolicy(
+      "https://example.com/dashboard"
+    );
+
+    expect(policy).not.toBeNull();
+    expect(
+      policy &&
+        followCanonicalServerRedirect(
+          policy,
+          "https://example.com/sign-in?next=%2Fdashboard"
+        )
+    ).toMatchObject({
+      originalOrigin: "https://example.com",
+      resolvedOrigin: "https://example.com",
+    });
+  });
+
+  it("allows an apex host to redirect to its www alias on the same port", () => {
+    const policy = createCanonicalRedirectPolicy("http://example.com:8080/");
+
+    expect(
+      policy &&
+        followCanonicalServerRedirect(
+          policy,
+          "http://www.example.com:8080/welcome"
+        )
+    ).toMatchObject({
+      originalOrigin: "http://example.com:8080",
+      resolvedOrigin: "http://www.example.com:8080",
+    });
+  });
+
+  it("allows a default-port HTTP origin to upgrade to HTTPS", () => {
+    const policy = createCanonicalRedirectPolicy("http://example.com/");
+
+    expect(
+      policy &&
+        followCanonicalServerRedirect(policy, "https://example.com/welcome")
+    ).toMatchObject({
+      originalOrigin: "http://example.com",
+      resolvedOrigin: "https://example.com",
+    });
+  });
+
+  it("allows the hostname alias and default-port upgrade in one redirect", () => {
+    const policy = createCanonicalRedirectPolicy("http://example.com/");
+
+    expect(
+      policy &&
+        followCanonicalServerRedirect(policy, "https://www.example.com/welcome")
+    ).toMatchObject({
+      originalOrigin: "http://example.com",
+      resolvedOrigin: "https://www.example.com",
+    });
+  });
+
+  it("does not treat an IP address as an apex host with a www alias", () => {
+    const policy = createCanonicalRedirectPolicy("http://127.0.0.1/");
+
+    expect(
+      policy && followCanonicalServerRedirect(policy, "http://www.127.0.0.1/")
+    ).toBeNull();
+  });
+
+  it("does not derive an alias from a host with repeated www prefixes", () => {
+    const policy = createCanonicalRedirectPolicy(
+      "https://www.www.example.com/"
+    );
+
+    expect(
+      policy &&
+        followCanonicalServerRedirect(policy, "https://www.example.com/")
+    ).toBeNull();
+  });
+
+  it.each([
+    ["https://app.example.com/", "https://www.app.example.com/"],
+    ["https://www.app.example.com/", "https://app.example.com/"],
+  ])("does not treat a project subdomain as an apex alias: %s", (initialUrl, nextUrl) => {
+    const policy = createCanonicalRedirectPolicy(initialUrl);
+
+    expect(policy && followCanonicalServerRedirect(policy, nextUrl)).toBeNull();
+  });
+
+  it("allows a www host to redirect to its anchored apex alias", () => {
+    const policy = createCanonicalRedirectPolicy("https://www.example.com/");
+
+    expect(
+      policy &&
+        followCanonicalServerRedirect(policy, "https://example.com/welcome")
+    ).toMatchObject({
+      originalOrigin: "https://www.example.com",
+      resolvedOrigin: "https://example.com",
+    });
+  });
+
+  it("allows one hostname change followed by one protocol upgrade", () => {
+    const policy = createCanonicalRedirectPolicy("http://example.com/");
+    const aliasedPolicy =
+      policy &&
+      followCanonicalServerRedirect(policy, "http://www.example.com/");
+
+    expect(
+      aliasedPolicy &&
+        followCanonicalServerRedirect(
+          aliasedPolicy,
+          "https://www.example.com/welcome"
+        )
+    ).toMatchObject({
+      originalOrigin: "http://example.com",
+      resolvedOrigin: "https://www.example.com",
+    });
+  });
+
+  it("rejects bouncing back after the anchored hostname alias is used", () => {
+    const policy = createCanonicalRedirectPolicy("https://example.com/");
+    const aliasedPolicy =
+      policy &&
+      followCanonicalServerRedirect(policy, "https://www.example.com/");
+
+    expect(
+      aliasedPolicy &&
+        followCanonicalServerRedirect(aliasedPolicy, "https://example.com/")
+    ).toBeNull();
+  });
+
+  it.each([
+    ["an arbitrary sibling", "https://app.example.com/"],
+    ["an unrelated host", "https://example.net/"],
+    ["a repeated www prefix", "https://www.www.example.com/"],
+    ["a protocol downgrade", "http://example.com/"],
+    ["an unexpected port", "https://example.com:8443/"],
+  ])("rejects %s", (_description, nextUrl) => {
+    const policy = createCanonicalRedirectPolicy("https://example.com/");
+
+    expect(policy && followCanonicalServerRedirect(policy, nextUrl)).toBeNull();
+  });
+
+  it.each([
+    [
+      "a custom source port",
+      "http://example.com:8080/",
+      "https://example.com/",
+    ],
+    [
+      "a custom destination port",
+      "http://example.com/",
+      "https://example.com:8443/",
+    ],
+  ])("rejects an HTTP to HTTPS upgrade from %s", (_description, initialUrl, nextUrl) => {
+    const policy = createCanonicalRedirectPolicy(initialUrl);
+
+    expect(policy && followCanonicalServerRedirect(policy, nextUrl)).toBeNull();
+  });
+
+  it.each([
+    "not a URL",
+    "file:///tmp/index.html",
+    "https://user@example.com/",
+    "https://user:secret@example.com/",
+  ])("rejects an invalid initial target: %s", (initialUrl) => {
+    expect(createCanonicalRedirectPolicy(initialUrl)).toBeNull();
+  });
+
+  it.each([
+    "not a URL",
+    "data:text/html,hello",
+    "https://user@example.com/",
+    "https://user:secret@example.com/",
+  ])("rejects an invalid redirect target: %s", (nextUrl) => {
+    const policy = createCanonicalRedirectPolicy("https://example.com/");
+
+    expect(policy && followCanonicalServerRedirect(policy, nextUrl)).toBeNull();
+  });
+});

--- a/test/e2e/docs-page.spec.ts
+++ b/test/e2e/docs-page.spec.ts
@@ -71,7 +71,7 @@ test("expands and copies the full recommended prompt from a ten-line preview", a
   await expect(readMore).toHaveAttribute("aria-expanded", "false");
   const controlledRegion = await getControlledRegion(page, readMore);
   expect(await controlledRegion.innerText()).toContain("--prompt");
-  expect(await controlledRegion.innerText()).not.toContain("--check-overflow");
+  expect(await controlledRegion.innerText()).not.toContain("--check-ui");
   const collapsedMetrics = await getPromptHeightMetrics(prompt);
   expect(collapsedMetrics.scrollHeight).toBeGreaterThan(
     collapsedMetrics.clientHeight
@@ -139,7 +139,8 @@ test("documents the CLI before the optional agent workflow", async ({
     .getByRole("button", { exact: true, name: "Read more" })
     .click();
   await expect(publicAgentPrompt).toContainText("--prompt");
-  await expect(publicAgentPrompt).toContainText("--check-overflow");
+  await expect(publicAgentPrompt).toContainText("--check-ui");
+  await expect(publicAgentPrompt).not.toContainText("--check-overflow");
   await expect(publicAgentPrompt).toContainText("monorepo");
   await expect(publicAgentPrompt).toContainText("production");
   await expect(publicAgentPrompt).toContainText("approval");
@@ -163,20 +164,28 @@ test("documents the CLI before the optional agent workflow", async ({
     page.locator("#options dt").getByText("--agent <agent>", { exact: true })
   ).toBeVisible();
   await expect(
-    page
-      .locator("#options dt")
-      .getByText("--check-overflow <url>", { exact: true })
+    page.locator("#options dt").getByText("--check-ui <url>", { exact: true })
   ).toBeVisible();
+  await expect(
+    page.getByRole("link", { exact: true, name: "UI checks" })
+  ).toHaveAttribute("href", "#ui-check");
   await expect(page.getByText("production-polish")).toBeVisible();
 
-  const overflowCheck = page.locator("#overflow-check");
-  await expect(overflowCheck).toContainText(
-    "--check-overflow http://localhost:3000 --route /dashboard"
+  const uiCheck = page.locator("#ui-check");
+  await expect(uiCheck).toContainText(
+    "--check-ui http://localhost:3000 --route /dashboard"
   );
-  await expect(overflowCheck).toContainText("Mobile: 320 × 820");
-  await expect(overflowCheck).toContainText("Desktop: 1440 × 1000");
-  await expect(overflowCheck).toContainText(
-    "standalone rendered check, not another source-audit rule"
+  await expect(uiCheck).toContainText("Mobile: 320 × 820");
+  await expect(uiCheck).toContainText("Desktop: 1440 × 1000");
+  await expect(uiCheck).toContainText(
+    "rendered UI suite, not another source-audit rule"
+  );
+  await expect(uiCheck).toContainText("server-side canonical redirects");
+  await expect(uiCheck).toContainText(
+    "client-side cross-origin navigations remain blocked"
+  );
+  await expect(uiCheck).toContainText(
+    "human output also identifies the originally requested origin"
   );
 
   const agentPrompt = page.locator("#agent-prompt");

--- a/test/e2e/home-page.spec.ts
+++ b/test/e2e/home-page.spec.ts
@@ -71,7 +71,7 @@ test("shows and copies the full project-aware prompt from a ten-line preview", a
   await expect(readMore).toHaveAttribute("aria-expanded", "false");
   const controlledRegion = await getControlledRegion(page, readMore);
   expect(await controlledRegion.innerText()).toContain("--prompt");
-  expect(await controlledRegion.innerText()).not.toContain("--check-overflow");
+  expect(await controlledRegion.innerText()).not.toContain("--check-ui");
   const collapsedMetrics = await getPromptHeightMetrics(prompt);
   expect(collapsedMetrics.scrollHeight).toBeGreaterThan(
     collapsedMetrics.clientHeight
@@ -105,7 +105,8 @@ test("shows and copies the full project-aware prompt from a ten-line preview", a
   );
 
   await expect(prompt).toContainText("--prompt");
-  await expect(prompt).toContainText("--check-overflow");
+  await expect(prompt).toContainText("--check-ui");
+  await expect(prompt).not.toContainText("--check-overflow");
   await expect(prompt).toContainText("monorepo");
   await expect(prompt).toContainText("production");
   await expect(prompt).toContainText("approval");

--- a/test/e2e/metadata.spec.ts
+++ b/test/e2e/metadata.spec.ts
@@ -24,7 +24,7 @@ const PAGE_METADATA = [
   {
     browserTitle: "Shadscan CLI documentation | shadscan",
     description:
-      "Run Shadscan, check rendered horizontal overflow, inspect a progress-bar score, launch a coding agent, and enforce score thresholds.",
+      "Run Shadscan, check rendered UI at mobile and desktop widths, inspect a progress-bar score, launch a coding agent, and enforce score thresholds.",
     imagePath: "/docs/opengraph-image",
     path: "/docs",
     socialTitle: "Shadscan CLI documentation | shadscan",

--- a/test/e2e/overflow-check.spec.ts
+++ b/test/e2e/overflow-check.spec.ts
@@ -45,6 +45,10 @@ interface OverflowReport {
     maximumOverflowPx: number;
     measurements: number;
   };
+  target: {
+    origin: string;
+    pages: string[];
+  };
 }
 
 interface CliProcessError extends Error {
@@ -212,6 +216,12 @@ let fixtureServer: Server | undefined;
 let crossOriginServer: Server | undefined;
 let fixtureOrigin = "";
 let crossOrigin = "";
+let canonicalOrigin = "";
+let canonicalWwwOrigin = "";
+const canonicalRequests: Array<{ host: string; pathname: string }> = [];
+let crossOriginRequests = 0;
+let clientHopCanonicalRequests = 0;
+let clientReloadCanonicalRequests = 0;
 let emptyWorkingDirectory = "";
 
 const listenOnEphemeralPort = async (
@@ -252,6 +262,7 @@ test.beforeAll(async () => {
     join(tmpdir(), "shadscan-overflow-e2e-")
   );
   crossOriginServer = createServer((_request, response) => {
+    crossOriginRequests += 1;
     response.writeHead(200, {
       "cache-control": "no-store",
       "content-type": "text/html; charset=utf-8",
@@ -269,6 +280,123 @@ test.beforeAll(async () => {
       request.url ?? "/",
       `http://${request.headers.host ?? "127.0.0.1"}`
     );
+
+    if (
+      requestUrl.pathname === "/redirect-canonical" ||
+      requestUrl.pathname === "/fits" ||
+      requestUrl.pathname === "/vertical-only"
+    ) {
+      canonicalRequests.push({
+        host: request.headers.host ?? "",
+        pathname: requestUrl.pathname,
+      });
+    }
+
+    if (requestUrl.pathname === "/redirect-canonical") {
+      response.writeHead(308, {
+        "cache-control": "no-store",
+        location: `${canonicalWwwOrigin}/fits?redirected=private#result`,
+      });
+      response.end();
+      return;
+    }
+
+    if (requestUrl.pathname === "/redirect-canonical-third") {
+      response.writeHead(308, {
+        "cache-control": "no-store",
+        location: `${canonicalWwwOrigin}/redirect-third`,
+      });
+      response.end();
+      return;
+    }
+
+    if (requestUrl.pathname === "/redirect-third") {
+      response.writeHead(302, {
+        "cache-control": "no-store",
+        location: `${crossOrigin}/fits?token=must-not-leak#private`,
+      });
+      response.end();
+      return;
+    }
+
+    if (requestUrl.pathname === "/client-canonical") {
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        "content-type": "text/html; charset=utf-8",
+      });
+      response.end(
+        `<!doctype html><html><head><title>Fixture</title></head><body><main>Redirecting</main><script>setTimeout(()=>location.replace('${canonicalWwwOrigin}/fits?token=must-not-leak#private'),100)</script></body></html>`
+      );
+      return;
+    }
+
+    if (requestUrl.pathname === "/client-hop-canonical") {
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        "content-type": "text/html; charset=utf-8",
+      });
+      response.end(
+        "<!doctype html><html><head><title>Fixture</title></head><body><main>Redirecting</main><script>location.replace('/client-hop-bounce?token=client-hop-secret')</script></body></html>"
+      );
+      return;
+    }
+
+    if (requestUrl.pathname === "/client-hop-bounce") {
+      response.writeHead(302, {
+        "cache-control": "no-store",
+        location: `${canonicalWwwOrigin}/client-hop-sink?token=client-hop-secret`,
+      });
+      response.end();
+      return;
+    }
+
+    if (requestUrl.pathname === "/client-hop-sink") {
+      clientHopCanonicalRequests += 1;
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        "content-type": "text/html; charset=utf-8",
+      });
+      response.end(
+        "<!doctype html><html><head><title>Fixture</title></head><body><main>Canonical sink</main></body></html>"
+      );
+      return;
+    }
+
+    if (requestUrl.pathname === "/client-reload-canonical") {
+      const hasReloadCookie = (request.headers.cookie ?? "")
+        .split(";")
+        .some((cookie) => cookie.trim() === "shadscan_client_reload=1");
+      if (hasReloadCookie) {
+        response.writeHead(302, {
+          "cache-control": "no-store",
+          location: `${canonicalWwwOrigin}/client-reload-sink?token=client-reload-secret`,
+        });
+        response.end();
+        return;
+      }
+
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        "content-type": "text/html; charset=utf-8",
+        "set-cookie": "shadscan_client_reload=1; Path=/; SameSite=Lax",
+      });
+      response.end(
+        "<!doctype html><html><head><title>Fixture</title></head><body><main>Reloading</main><script>location.replace(location.href)</script></body></html>"
+      );
+      return;
+    }
+
+    if (requestUrl.pathname === "/client-reload-sink") {
+      clientReloadCanonicalRequests += 1;
+      response.writeHead(200, {
+        "cache-control": "no-store",
+        "content-type": "text/html; charset=utf-8",
+      });
+      response.end(
+        "<!doctype html><html><head><title>Fixture</title></head><body><main>Canonical reload sink</main></body></html>"
+      );
+      return;
+    }
 
     if (requestUrl.pathname === "/redirect-same") {
       response.writeHead(302, {
@@ -320,6 +448,9 @@ test.beforeAll(async () => {
     fixtureServer,
     "The overflow fixture server"
   );
+  const fixturePort = new URL(fixtureOrigin).port;
+  canonicalOrigin = `http://localhost:${fixturePort}`;
+  canonicalWwwOrigin = `http://www.localhost:${fixturePort}`;
 });
 
 test.afterAll(async () => {
@@ -338,7 +469,7 @@ test.afterAll(async () => {
 test("passes fitting, contained, subpixel, vertical, and settled layouts", async () => {
   const secret = "must-not-appear";
   const result = await runOverflowCheck([
-    "--check-overflow",
+    "--check-ui",
     `${fixtureOrigin}/fits?token=${secret}#private`,
     "--route",
     "/local-scroller",
@@ -354,8 +485,8 @@ test("passes fitting, contained, subpixel, vertical, and settled layouts", async
     "--no-interactive",
   ]);
 
-  expect(result.exitCode).toBe(0);
   expect(result.stderr).toBe("");
+  expect(result.exitCode).toBe(0);
   expect(result.stdout).not.toContain(secret);
 
   const report = JSON.parse(result.stdout) as OverflowReport;
@@ -392,7 +523,7 @@ test("passes fitting, contained, subpixel, vertical, and settled layouts", async
 
 test("detects document overflow across layout and rendering mechanisms", async () => {
   const result = await runOverflowCheck([
-    "--check-overflow",
+    "--check-ui",
     `${fixtureOrigin}/one-pixel`,
     "--route",
     "/forced-scrollbar",
@@ -501,7 +632,7 @@ test("detects document overflow across layout and rendering mechanisms", async (
 
 test("measures the default motion profile and document coordinates", async () => {
   const result = await runOverflowCheck([
-    "--check-overflow",
+    "--check-ui",
     `${fixtureOrigin}/hash-overflow#target`,
     "--route",
     "/motion-overflow",
@@ -540,7 +671,7 @@ test("measures the default motion profile and document coordinates", async () =>
 
 test("waits for fonts and follows a same-origin HTTP redirect", async () => {
   const result = await runOverflowCheck([
-    "--check-overflow",
+    "--check-ui",
     `${fixtureOrigin}/redirect-same`,
     "--route",
     "/delayed-font-ready",
@@ -574,6 +705,186 @@ test("waits for fonts and follows a same-origin HTTP redirect", async () => {
   ).toBe(true);
 });
 
+test("follows a canonical server redirect and pins later routes", async () => {
+  canonicalRequests.length = 0;
+  const result = await runOverflowCheck([
+    "--check-ui",
+    `${canonicalOrigin}/redirect-canonical?token=must-not-leak#private`,
+    "--route",
+    "/vertical-only",
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(result.stderr).toBe("");
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).not.toContain("must-not-leak");
+
+  const report = JSON.parse(result.stdout) as OverflowReport;
+  expect(report).toMatchObject({
+    status: "pass",
+    summary: { failed: 0, maximumOverflowPx: 0, measurements: 4 },
+    target: { origin: canonicalWwwOrigin },
+  });
+  expect(
+    report.results.every(
+      ({ httpStatus, status }) => httpStatus === 200 && status === "pass"
+    )
+  ).toBe(true);
+  expect(
+    report.results
+      .filter(
+        ({ page }) => page === "/redirect-canonical?[redacted]#[redacted]"
+      )
+      .every(({ finalPath }) => finalPath === "/fits")
+  ).toBe(true);
+
+  const canonicalHost = new URL(canonicalOrigin).host;
+  const canonicalWwwHost = new URL(canonicalWwwOrigin).host;
+  expect(
+    canonicalRequests.filter(
+      ({ host, pathname }) =>
+        host === canonicalHost && pathname === "/redirect-canonical"
+    )
+  ).toHaveLength(2);
+  expect(
+    canonicalRequests.filter(
+      ({ host, pathname }) =>
+        host === canonicalWwwHost && pathname === "/vertical-only"
+    )
+  ).toHaveLength(2);
+});
+
+test("canonical navigation provenance rejects a client-side host alias", async () => {
+  canonicalRequests.length = 0;
+  const result = await runOverflowCheck([
+    "--check-ui",
+    `${canonicalOrigin}/client-canonical`,
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toBe("");
+  expect(result.stderr).not.toContain("must-not-leak");
+  expect(JSON.parse(result.stderr)).toMatchObject({
+    error: {
+      code: "OVERFLOW_TARGET_UNAVAILABLE",
+    },
+    schemaVersion: 1,
+  });
+  expect(
+    canonicalRequests.filter(
+      ({ host, pathname }) =>
+        host === new URL(canonicalWwwOrigin).host && pathname === "/fits"
+    )
+  ).toHaveLength(0);
+});
+
+test("canonical navigation provenance rejects an alias after a client-side same-origin hop", async () => {
+  clientHopCanonicalRequests = 0;
+  const result = await runOverflowCheck([
+    "--check-ui",
+    `${canonicalOrigin}/client-hop-canonical`,
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(
+    clientHopCanonicalRequests,
+    "the canonical destination must be blocked before network egress"
+  ).toBe(0);
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toBe("");
+  expect(result.stderr).not.toContain("client-hop-secret");
+  expect(JSON.parse(result.stderr)).toMatchObject({
+    error: {
+      code: "OVERFLOW_TARGET_UNAVAILABLE",
+    },
+    schemaVersion: 1,
+  });
+});
+
+test("canonical navigation provenance rejects an alias after a client-side same-URL reload", async () => {
+  clientReloadCanonicalRequests = 0;
+  const result = await runOverflowCheck([
+    "--check-ui",
+    `${canonicalOrigin}/client-reload-canonical?token=client-reload-secret`,
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(
+    clientReloadCanonicalRequests,
+    "the canonical destination must be blocked before network egress"
+  ).toBe(0);
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toBe("");
+  expect(result.stderr).not.toContain("client-reload-secret");
+  expect(JSON.parse(result.stderr)).toMatchObject({
+    error: {
+      code: "OVERFLOW_TARGET_UNAVAILABLE",
+    },
+    schemaVersion: 1,
+  });
+});
+
+test("canonical navigation provenance rejects a third-origin server hop", async () => {
+  crossOriginRequests = 0;
+  const result = await runOverflowCheck([
+    "--check-ui",
+    `${canonicalOrigin}/redirect-canonical-third`,
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toBe("");
+  expect(result.stderr).not.toContain("must-not-leak");
+  expect(JSON.parse(result.stderr)).toMatchObject({
+    error: {
+      code: "OVERFLOW_TARGET_UNAVAILABLE",
+    },
+    schemaVersion: 1,
+  });
+  expect(crossOriginRequests).toBe(0);
+});
+
+test("canonical origin pin rejects a later route that leaves the origin", async () => {
+  crossOriginRequests = 0;
+  const result = await runOverflowCheck([
+    "--check-ui",
+    `${canonicalOrigin}/redirect-canonical`,
+    "--route",
+    "/redirect-cross",
+    "--browser-executable",
+    chromium.executablePath(),
+    "--json",
+    "--no-interactive",
+  ]);
+
+  expect(result.exitCode).toBe(1);
+  expect(result.stdout).toBe("");
+  expect(result.stderr).not.toContain("must-not-leak");
+  expect(JSON.parse(result.stderr)).toMatchObject({
+    error: {
+      code: "OVERFLOW_TARGET_UNAVAILABLE",
+    },
+    schemaVersion: 1,
+  });
+  expect(crossOriginRequests).toBe(0);
+});
+
 test("rejects unstable, cross-origin, non-HTML, and unavailable targets", async () => {
   const cases = [
     {
@@ -600,7 +911,7 @@ test("rejects unstable, cross-origin, non-HTML, and unavailable targets", async 
 
   for (const { expectedCode, expectedSecret, target } of cases) {
     const result = await runOverflowCheck([
-      "--check-overflow",
+      "--check-ui",
       target,
       "--browser-executable",
       chromium.executablePath(),
@@ -622,7 +933,7 @@ test("rejects unstable, cross-origin, non-HTML, and unavailable targets", async 
 
 test("keeps operational failures off stdout", async () => {
   const result = await runOverflowCheck([
-    "--check-overflow",
+    "--check-ui",
     `${fixtureOrigin}/missing`,
     "--browser-executable",
     chromium.executablePath(),
@@ -640,7 +951,7 @@ test("keeps operational failures off stdout", async () => {
   });
 
   const clientRedirect = await runOverflowCheck([
-    "--check-overflow",
+    "--check-ui",
     `${fixtureOrigin}/client-redirect`,
     "--browser-executable",
     chromium.executablePath(),
@@ -659,7 +970,7 @@ test("keeps operational failures off stdout", async () => {
   });
 
   const client404 = await runOverflowCheck([
-    "--check-overflow",
+    "--check-ui",
     `${fixtureOrigin}/client-404`,
     "--browser-executable",
     chromium.executablePath(),
@@ -677,7 +988,7 @@ test("keeps operational failures off stdout", async () => {
   });
 
   const immediate404 = await runOverflowCheck([
-    "--check-overflow",
+    "--check-ui",
     `${fixtureOrigin}/immediate-404`,
     "--browser-executable",
     chromium.executablePath(),
@@ -695,7 +1006,7 @@ test("keeps operational failures off stdout", async () => {
   });
 
   const clientBlob = await runOverflowCheck([
-    "--check-overflow",
+    "--check-ui",
     `${fixtureOrigin}/client-blob`,
     "--browser-executable",
     chromium.executablePath(),

--- a/test/shadscan-web/agent-prompt.test.ts
+++ b/test/shadscan-web/agent-prompt.test.ts
@@ -13,7 +13,7 @@ const STOP_BEFORE_EDIT_PATTERN =
 describe("public agent audit prompt", () => {
   it("requests project-aware source and rendered checks without inventing targets", () => {
     expect(AGENT_AUDIT_PROMPT).toContain("--prompt");
-    expect(AGENT_AUDIT_PROMPT).toContain("--check-overflow");
+    expect(AGENT_AUDIT_PROMPT).toContain("--check-ui");
     expect(AGENT_AUDIT_PROMPT).toContain("--list-projects --json");
     expect(AGENT_AUDIT_PROMPT).toContain("--route");
 
@@ -33,12 +33,15 @@ describe("public agent audit prompt", () => {
     expect(AGENT_AUDIT_PROMPT).toContain("finalPath");
     expect(AGENT_AUDIT_PROMPT).toContain("httpStatus");
     expect(AGENT_AUDIT_PROMPT).toContain("public HTTPS origin");
+    expect(AGENT_AUDIT_PROMPT).toContain("final canonical origin");
+    expect(AGENT_AUDIT_PROMPT).toContain("client-side cross-origin");
     expect(AGENT_AUDIT_PROMPT).toContain("Never stop a reused");
     expect(AGENT_AUDIT_PROMPT).toContain("separate process argument");
     expect(AGENT_AUDIT_PROMPT).toContain("entire batch was not verified");
     expect(AGENT_AUDIT_PROMPT).toMatch(STOP_BEFORE_EDIT_PATTERN);
 
     expect(AGENT_AUDIT_PROMPT).not.toContain("localhost");
+    expect(AGENT_AUDIT_PROMPT).not.toContain("--check-overflow");
     expect(AGENT_AUDIT_PROMPT).not.toMatch(DASHBOARD_ROUTE_PATTERN);
     expect(AGENT_AUDIT_PROMPT).not.toMatch(LITERAL_URL_PATTERN);
     expect(AGENT_AUDIT_PROMPT).not.toMatch(DOMAIN_PATTERN);


### PR DESCRIPTION
## Summary

- make `--check-ui` the public rendered-check entry point while keeping `--check-overflow` as a hidden compatibility alias
- safely follow server-proven apex/www and HTTP-to-HTTPS canonical redirects, then pin the resolved origin across viewports and routes
- update the landing/docs AI prompt, CLI documentation, browser regressions, and packed-artifact smoke coverage

## Safety

- validates every Chromium main-frame redirect at request stage before network egress
- limits canonical aliases to conservative two-label apex/www pairs (plus localhost) and blocks subdomains, unrelated origins, changed ports, HTTPS downgrades, credentials, and client-side cross-origin chains
- preserves overflow report schema v1; no ruleset, catalog, or package-version change

## Verification

- `pnpm check`
- `pnpm docs:check`
- CLI typecheck and all 757 CLI tests
- API tests (140) and web tests (170)
- full browser E2E plus final rendered-check suite (12/12)
- dependency audit, self-audit (100/100 A), production build/trace
- packed CLI smoke with Chromium
- live `https://orcdev.com` check: resolves to `https://www.orcdev.com`, passes mobile and desktop with 0 px overflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `--check-ui <url>` command for rendered UI checks across mobile and desktop viewports.
  - Added route validation, canonical redirect handling, resolved-origin reporting, and protection against unsafe cross-origin navigation or HTTPS downgrades.
  - Retained `--check-overflow` as a compatibility alias.

- **Documentation**
  - Updated CLI, web documentation, examples, metadata, and navigation to describe the broader UI-check workflow.

- **Bug Fixes**
  - Improved origin consistency and security during redirected and multi-route checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->