### PR TITLE
feat(cli): show rendered UI check progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ stable releases published under `latest`.
 
 - Interactive human `--check-ui` runs now show an immediate three-phase stderr
   checklist: `Resolving UI target`, `Checking mobile and desktop layouts`, and
-  `Preparing UI report`. JSON, CI, non-TTY stderr, and `--no-interactive` runs
-  remain quiet.
+  `Preparing UI report`. JSON, CI, `TERM=dumb`, non-TTY stderr, and
+  `--no-interactive` runs remain quiet.
 
 ## 0.15.0 - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ stable releases published under `latest`.
 
 ## Unreleased
 
+### Added
+
+- Interactive human `--check-ui` runs now show an immediate three-phase stderr
+  checklist: `Resolving UI target`, `Checking mobile and desktop layouts`, and
+  `Preparing UI report`. JSON, CI, non-TTY stderr, and `--no-interactive` runs
+  remain quiet.
+
 ## 0.15.0 - 2026-08-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ bunx @shadscan/cli
 Commands resolve to the latest stable release. Prereleases are published
 under the `next` tag (`@shadscan/cli@next`) for early testing.
 
-Interactive human scans show progress immediately and keep each completed phase
-above the final report:
+Interactive human source audits show progress immediately and keep each
+completed phase above the final report:
 
 ```text
 ✓ Resolving project
@@ -63,9 +63,18 @@ above the final report:
 ✓ Preparing report
 ```
 
-JSON, prompt, CI, non-TTY stderr, and `--no-interactive` output stay quiet.
-Redirecting stdout keeps the report clean while progress remains on an eligible
-stderr terminal.
+Rendered UI checks use phases specific to browser work:
+
+```text
+✓ Resolving UI target
+✓ Checking mobile and desktop layouts
+✓ Preparing UI report
+```
+
+Both checklists are written to stderr for interactive human output only. JSON,
+CI, non-TTY stderr, and `--no-interactive` output stay quiet; prompt output also
+stays quiet. Redirecting stdout keeps the report clean while progress remains on
+an eligible stderr terminal.
 
 Every interactive scan ends with a short menu — pick with the arrow keys and
 Enter: copy the agent handoff to your clipboard, print it, launch an installed

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ Rendered UI checks use phases specific to browser work:
 ```
 
 Both checklists are written to stderr for interactive human output only. JSON,
-CI, non-TTY stderr, and `--no-interactive` output stay quiet; prompt output also
-stays quiet. Redirecting stdout keeps the report clean while progress remains on
-an eligible stderr terminal.
+CI, `TERM=dumb`, non-TTY stderr, and `--no-interactive` output stay quiet;
+prompt output also stays quiet. Redirecting stdout keeps the report clean while
+progress remains on an eligible stderr terminal.
 
 Every interactive scan ends with a short menu — pick with the arrow keys and
 Enter: copy the agent handoff to your clipboard, print it, launch an installed

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -101,8 +101,7 @@ const CLI_OPTIONS = [
     option: "--roast",
   },
   {
-    description:
-      "Disable the local post-scan menu and all Shadscan follow-up prompts.",
+    description: "Disable terminal progress and follow-up prompts.",
     option: "--no-interactive",
   },
   {
@@ -318,6 +317,21 @@ export default function DocsPage() {
             beginning with <code>/</code>, up to ten pages in total. Routes
             cannot contain query strings or fragments.
           </p>
+          <h3>Follow progress in the terminal</h3>
+          <DocsCodeBlock
+            code={
+              "✓ Resolving UI target\n✓ Checking mobile and desktop layouts\n✓ Preparing UI report"
+            }
+            label="Interactive UI-check progress"
+            language="text"
+          />
+          <p>
+            Interactive human runs write this checklist to stderr and leave the
+            completed phases visible above the final report. JSON, CI, non-TTY
+            stderr, and <code>--no-interactive</code> output stay quiet.
+            Redirecting stdout keeps the report clean while progress remains on
+            an eligible stderr terminal.
+          </p>
           <p>
             The initial request may follow narrowly validated server-side
             canonical redirects between a conventional two-label apex host and
@@ -532,9 +546,9 @@ export default function DocsPage() {
             blocking Shadscan hook protects the project yet. Pick with the arrow
             keys and Enter — the handoff is highlighted first, so a single Enter
             grabs it. Press <code>Esc</code> to keep just the score, or use{" "}
-            <code>--no-interactive</code> to suppress the menu entirely.
-            Category-scoped scans do not offer a hook because their score cannot
-            establish a full-project floor.
+            <code>--no-interactive</code> to suppress terminal progress and the
+            menu entirely. Category-scoped scans do not offer a hook because
+            their score cannot establish a full-project floor.
           </p>
           <h3>Preview the exact hook plan</h3>
           <div className="not-typeset mt-4">

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -327,10 +327,11 @@ export default function DocsPage() {
           />
           <p>
             Interactive human runs write this checklist to stderr and leave the
-            completed phases visible above the final report. JSON, CI, non-TTY
-            stderr, and <code>--no-interactive</code> output stay quiet.
-            Redirecting stdout keeps the report clean while progress remains on
-            an eligible stderr terminal.
+            completed phases visible above the final report. JSON, CI,{" "}
+            <code>TERM=dumb</code>, non-TTY stderr, and{" "}
+            <code>--no-interactive</code> output stay quiet. Redirecting stdout
+            keeps the report clean while progress remains on an eligible stderr
+            terminal.
           </p>
           <p>
             The initial request may follow narrowly validated server-side

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -82,8 +82,8 @@ shadscan --check-ui <url> [--route <path> ...]
   intact. Progress begins immediately, keeps completed phases visible, and
   depends on stderr terminal capabilities rather than stdin or stdout TTY state.
   Rendered UI checks use `Resolving UI target`, `Checking mobile and desktop
-  layouts`, and `Preparing UI report`. JSON, prompt, CI, non-TTY stderr, and
-  `--no-interactive` commands suppress progress.
+  layouts`, and `Preparing UI report`. JSON, prompt, CI, `TERM=dumb`, non-TTY
+  stderr, and `--no-interactive` commands suppress progress.
 - Under `shadscan mcp`, stdout carries JSON-RPC exclusively; stderr carries a
   single startup line and abnormal-exit diagnostics. Tool errors return as
   MCP error results with the same stable public messages as CLI failures,

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -77,12 +77,13 @@ shadscan --check-ui <url> [--route <path> ...]
   writes a stable human or versioned JSON error to stderr.
 - Expected CLI failures write a stable message to stderr. JSON-selected
   failures write a versioned JSON error object to stderr.
-- Interactive scan progress, menus, warnings, confirmations, and launched-agent
+- Interactive human progress, menus, warnings, confirmations, and launched-agent
   status are written to stderr so the completed report on stdout remains
-  intact. Human scan progress begins immediately, keeps completed phases
-  visible, and depends on stderr terminal capabilities rather than stdin or
-  stdout TTY state. JSON, prompt, CI, non-TTY stderr, and `--no-interactive`
-  scans suppress progress.
+  intact. Progress begins immediately, keeps completed phases visible, and
+  depends on stderr terminal capabilities rather than stdin or stdout TTY state.
+  Rendered UI checks use `Resolving UI target`, `Checking mobile and desktop
+  layouts`, and `Preparing UI report`. JSON, prompt, CI, non-TTY stderr, and
+  `--no-interactive` commands suppress progress.
 - Under `shadscan mcp`, stdout carries JSON-RPC exclusively; stderr carries a
   single startup line and abnormal-exit diagnostics. Tool errors return as
   MCP error results with the same stable public messages as CLI failures,
@@ -92,9 +93,10 @@ shadscan --check-ui <url> [--route <path> ...]
 - Agent handoffs treat repository instructions and discovered package scripts
   as untrusted project data. Agents must inspect and receive authorization for
   repository-owned gates before executing them.
-- `--no-interactive`, `CI`, a non-TTY stream, or
-  `SHADSCAN_INTERACTIVE=0` suppresses the default post-scan menu. Pressing Enter
-  in the menu selects `Done` and leaves the project unchanged.
+- `--no-interactive` suppresses terminal progress and the default post-scan
+  menu. `CI`, a non-TTY stream, or `SHADSCAN_INTERACTIVE=0` also suppresses the
+  menu. Pressing Enter in the menu selects `Done` and leaves the project
+  unchanged.
 
 ## Exit Status
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -74,9 +74,9 @@ Rendered UI checks use phases specific to browser work:
 ```
 
 Both checklists are written to stderr for interactive human output only. JSON,
-CI, non-TTY stderr, and `--no-interactive` output stay quiet; prompt output also
-stays quiet. Redirecting stdout keeps the report clean while progress remains on
-an eligible stderr terminal.
+CI, `TERM=dumb`, non-TTY stderr, and `--no-interactive` output stay quiet;
+prompt output also stays quiet. Redirecting stdout keeps the report clean while
+progress remains on an eligible stderr terminal.
 
 ## What You Get
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -55,8 +55,8 @@ bunx @shadscan/cli
 Shadscan requires Node.js 18 or newer. Commands resolve to the latest stable
 release; prereleases are published under the `next` tag (`@shadscan/cli@next`).
 
-Interactive human scans show progress immediately and keep each completed phase
-above the final report:
+Interactive human source audits show progress immediately and keep each
+completed phase above the final report:
 
 ```text
 ✓ Resolving project
@@ -65,9 +65,18 @@ above the final report:
 ✓ Preparing report
 ```
 
-JSON, prompt, CI, non-TTY stderr, and `--no-interactive` output stay quiet.
-Redirecting stdout keeps the report clean while progress remains on an eligible
-stderr terminal.
+Rendered UI checks use phases specific to browser work:
+
+```text
+✓ Resolving UI target
+✓ Checking mobile and desktop layouts
+✓ Preparing UI report
+```
+
+Both checklists are written to stderr for interactive human output only. JSON,
+CI, non-TTY stderr, and `--no-interactive` output stay quiet; prompt output also
+stays quiet. Redirecting stdout keeps the report clean while progress remains on
+an eligible stderr terminal.
 
 ## What You Get
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -579,25 +579,25 @@ const getOutputTerminalCapabilities = () =>
 const runUiCheckAction = async (
   {
     browserExecutable,
+    interactive,
     outputFormat,
     routes,
     target,
   }: {
     browserExecutable?: string;
+    interactive: boolean;
     outputFormat: OutputFormat;
     routes?: string[];
     target: string;
   },
   runtime: UiCheckRuntime = {}
 ): Promise<void> => {
-  const resolvedTarget = resolveOverflowCheckTarget({ routes, target });
-  let runBrowserCheck = runtime.runBrowserCheck;
-
-  if (!runBrowserCheck) {
-    ({ runOverflowBrowserCheck: runBrowserCheck } = await import(
-      "./overflow-check/browser"
-    ));
-  }
+  const progress = createCliScanProgress(
+    outputFormat === "human" && interactive
+  );
+  const resolvedTarget = await progress.run("Resolving UI target", () =>
+    resolveOverflowCheckTarget({ routes, target })
+  );
 
   const abortController = new AbortController();
   const abortCheck = (): void => abortController.abort();
@@ -605,28 +605,46 @@ const runUiCheckAction = async (
   process.once("SIGTERM", abortCheck);
 
   try {
-    const browserResult = await runBrowserCheck({
-      browserExecutable,
-      origin: resolvedTarget.origin,
-      pages: resolvedTarget.pages,
-      signal: abortController.signal,
-    });
-    const report = evaluateOverflowCheck({
-      durationMs: browserResult.durationMs,
-      measurements: browserResult.measurements,
-      target: {
-        origin: browserResult.origin,
-        pages: resolvedTarget.pages.map((page) => page.displayPath),
-      },
-    });
-    const output =
-      outputFormat === "json"
-        ? `${JSON.stringify(report, null, 2)}\n`
-        : renderOverflowCheckReport(report, {
-            requestedOrigin: resolvedTarget.origin,
-            terminal: getOutputTerminalCapabilities(),
-          });
+    const browserResult = await progress.run(
+      "Checking mobile and desktop layouts",
+      async () => {
+        let runBrowserCheck = runtime.runBrowserCheck;
 
+        if (!runBrowserCheck) {
+          ({ runOverflowBrowserCheck: runBrowserCheck } = await import(
+            "./overflow-check/browser"
+          ));
+        }
+
+        return await runBrowserCheck({
+          browserExecutable,
+          origin: resolvedTarget.origin,
+          pages: resolvedTarget.pages,
+          signal: abortController.signal,
+        });
+      }
+    );
+    const { output, report } = await progress.run("Preparing UI report", () => {
+      const preparedReport = evaluateOverflowCheck({
+        durationMs: browserResult.durationMs,
+        measurements: browserResult.measurements,
+        target: {
+          origin: browserResult.origin,
+          pages: resolvedTarget.pages.map((page) => page.displayPath),
+        },
+      });
+      const preparedOutput =
+        outputFormat === "json"
+          ? `${JSON.stringify(preparedReport, null, 2)}\n`
+          : renderOverflowCheckReport(preparedReport, {
+              requestedOrigin: resolvedTarget.origin,
+              terminal: getOutputTerminalCapabilities(),
+            });
+
+      return { output: preparedOutput, report: preparedReport };
+    });
+
+    progress.finish();
     process.stdout.write(output);
     if (report.status === "fail") {
       process.exitCode = 1;
@@ -758,6 +776,7 @@ const runScanAction = async (
     await runUiCheckAction(
       {
         browserExecutable: options.browserExecutable,
+        interactive: options.interactive,
         outputFormat,
         routes: options.route,
         target: uiCheckTarget,
@@ -988,7 +1007,10 @@ const createProgram = (runtime: UiCheckRuntime = {}): Command => {
     )
     .option("--no-roast", "Use neutral human output.")
     .option("--roast", "Force roast copy in CI and JSON output.")
-    .option("--no-interactive", "Disable Shadscan follow-up prompts.")
+    .option(
+      "--no-interactive",
+      "Disable terminal progress and follow-up prompts."
+    )
     .option(
       "--list-projects",
       "List the workspace packages shadscan found, without scanning."

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -32,12 +32,46 @@ const PROGRESS_PHASE_LABELS = [
   "Evaluating UI rules",
   "Preparing report",
 ] as const;
+const UI_CHECK_PROGRESS_PHASE_LABELS = [
+  "Resolving UI target",
+  "Checking mobile and desktop layouts",
+  "Preparing UI report",
+] as const;
+
+const createPassingUiCheckResult = () => ({
+  browser: { name: "chromium", version: "123" },
+  durationMs: 12,
+  measurements: [
+    {
+      clientWidth: 320,
+      finalPath: "/",
+      forcedScrollbar: false,
+      httpStatus: 200,
+      page: "/",
+      scrollWidth: 320,
+      viewport: { height: 820, name: "mobile", width: 320 } as const,
+    },
+    {
+      clientWidth: 1440,
+      finalPath: "/",
+      forcedScrollbar: false,
+      httpStatus: 200,
+      page: "/",
+      scrollWidth: 1440,
+      viewport: { height: 1000, name: "desktop", width: 1440 } as const,
+    },
+  ],
+  origin: "http://127.0.0.1:3000",
+});
 
 const setInteractiveTerminal = (): (() => void) => {
   const streams = [process.stdin, process.stdout, process.stderr];
   const descriptors = streams.map((stream) =>
     Object.getOwnPropertyDescriptor(stream, "isTTY")
   );
+  const previousTerm = process.env.TERM;
+
+  process.env.TERM = "xterm-256color";
 
   for (const stream of streams) {
     Object.defineProperty(stream, "isTTY", {
@@ -47,6 +81,12 @@ const setInteractiveTerminal = (): (() => void) => {
   }
 
   return () => {
+    if (previousTerm === undefined) {
+      Reflect.deleteProperty(process.env, "TERM");
+    } else {
+      process.env.TERM = previousTerm;
+    }
+
     for (const [index, stream] of streams.entries()) {
       const descriptor = descriptors[index];
       if (descriptor) {
@@ -124,6 +164,78 @@ const captureStreams = async (
   }
 };
 
+const captureUiCheckStreams = async ({
+  args = [],
+  ci,
+  runBrowserCheck = async () => createPassingUiCheckResult(),
+  stderrIsTTY = true,
+  stdoutIsTTY = true,
+  term = "xterm-256color",
+  uiFlag = "--check-ui",
+}: {
+  args?: string[];
+  ci?: string;
+  runBrowserCheck?: () => Promise<
+    ReturnType<typeof createPassingUiCheckResult>
+  >;
+  stderrIsTTY?: boolean;
+  stdoutIsTTY?: boolean;
+  term?: string;
+  uiFlag?: "--check-overflow" | "--check-ui";
+}): Promise<{ failure: unknown; stderr: string; stdout: string }> => {
+  const previousCi = process.env.CI;
+  const restoreTerminal = setInteractiveTerminal();
+  let failure: unknown;
+  let stderr = "";
+  let stdout = "";
+  const writeError = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation((chunk) => {
+      stderr += String(chunk);
+      return true;
+    });
+  const writeOutput = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation((chunk) => {
+      stdout += String(chunk);
+      return true;
+    });
+
+  process.env.TERM = term;
+  if (ci === undefined) {
+    Reflect.deleteProperty(process.env, "CI");
+  } else {
+    process.env.CI = ci;
+  }
+  Object.defineProperty(process.stderr, "isTTY", {
+    configurable: true,
+    value: stderrIsTTY,
+  });
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value: stdoutIsTTY,
+  });
+
+  try {
+    await createProgram({ runBrowserCheck }).parseAsync([
+      "node",
+      "shadscan",
+      uiFlag,
+      "http://127.0.0.1:3000",
+      ...args,
+    ]);
+  } catch (error) {
+    failure = error;
+  } finally {
+    restoreEnvironment({ CI: previousCi });
+    restoreTerminal();
+    writeError.mockRestore();
+    writeOutput.mockRestore();
+  }
+
+  return { failure, stderr, stdout };
+};
+
 afterEach(() => {
   process.exitCode = undefined;
   vi.restoreAllMocks();
@@ -146,6 +258,7 @@ describe("CLI contract", () => {
     expect(help).toContain("--browser-executable <path>");
     expect(help).toContain("--check-ui.");
     expect(help).toContain("--no-interactive");
+    expect(help).toContain("Disable terminal progress and follow-up prompts.");
     expect(program.commands.map((command) => command.name())).toContain(
       "setup"
     );
@@ -230,6 +343,7 @@ describe("CLI contract", () => {
     try {
       await runUiCheckAction(
         {
+          interactive: false,
           outputFormat: "json",
           target: "http://127.0.0.1:3000",
         },
@@ -248,6 +362,173 @@ describe("CLI contract", () => {
       target: { origin: "http://www.example.test" },
     });
     expect(process.exitCode).toBe(1);
+  });
+
+  it("shows UI-check progress before the browser runner finishes", async () => {
+    const previousCi = process.env.CI;
+    const restoreTerminal = setInteractiveTerminal();
+    let resolveBrowserCheck:
+      | ((value: ReturnType<typeof createPassingUiCheckResult>) => void)
+      | undefined;
+    const runBrowserCheck = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof createPassingUiCheckResult>>(
+          (resolve) => {
+            resolveBrowserCheck = resolve;
+          }
+        )
+    );
+    let stderr = "";
+    let stdout = "";
+    const writeError = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk) => {
+        stderr += String(chunk);
+        return true;
+      });
+    const writeOutput = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk) => {
+        stdout += String(chunk);
+        return true;
+      });
+
+    Reflect.deleteProperty(process.env, "CI");
+
+    try {
+      const command = createProgram({ runBrowserCheck }).parseAsync([
+        "node",
+        "shadscan",
+        "--check-ui",
+        "http://127.0.0.1:3000",
+      ]);
+
+      await vi.waitFor(() => {
+        expect(stderr).toContain(UI_CHECK_PROGRESS_PHASE_LABELS[1]);
+      });
+      expect(stdout).toBe("");
+
+      resolveBrowserCheck?.(createPassingUiCheckResult());
+      await command;
+    } finally {
+      restoreEnvironment({ CI: previousCi });
+      restoreTerminal();
+      writeError.mockRestore();
+      writeOutput.mockRestore();
+    }
+
+    for (const label of UI_CHECK_PROGRESS_PHASE_LABELS) {
+      expect(stderr).toContain(label);
+      expect(stdout).not.toContain(label);
+    }
+    expect(stdout).toContain("PASS");
+  });
+
+  it("completes every UI-check progress phase before reporting overflow", async () => {
+    const runBrowserCheck = vi.fn(() => {
+      const result = createPassingUiCheckResult();
+      return Promise.resolve({
+        ...result,
+        measurements: result.measurements.map((measurement, index) =>
+          index === 0
+            ? { ...measurement, scrollWidth: measurement.clientWidth + 1 }
+            : measurement
+        ),
+      });
+    });
+
+    const output = await captureUiCheckStreams({ runBrowserCheck });
+
+    expect(output.failure).toBeUndefined();
+    for (const label of UI_CHECK_PROGRESS_PHASE_LABELS) {
+      expect(output.stderr).toContain(label);
+      expect(output.stdout).not.toContain(label);
+    }
+    expect(output.stderr.match(/✓/gu)).toHaveLength(3);
+    expect(output.stderr).not.toContain("✗");
+    expect(output.stdout).toContain("CRITICAL FAIL");
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("marks an operational UI-check failure and propagates its error", async () => {
+    const sigintListeners = process.listenerCount("SIGINT");
+    const sigtermListeners = process.listenerCount("SIGTERM");
+    const failure = new OverflowCheckError(
+      "OVERFLOW_TARGET_UNAVAILABLE",
+      "The target page is unavailable."
+    );
+    const output = await captureUiCheckStreams({
+      runBrowserCheck: () => Promise.reject(failure),
+    });
+
+    expect(output.failure).toBe(failure);
+    expect(output.stdout).toBe("");
+    expect(output.stderr).toContain(UI_CHECK_PROGRESS_PHASE_LABELS[0]);
+    expect(output.stderr).toContain(UI_CHECK_PROGRESS_PHASE_LABELS[1]);
+    expect(output.stderr).not.toContain(UI_CHECK_PROGRESS_PHASE_LABELS[2]);
+    expect(output.stderr.match(/✓/gu)).toHaveLength(1);
+    expect(output.stderr.match(/✗/gu)).toHaveLength(1);
+    expect(process.listenerCount("SIGINT")).toBe(sigintListeners);
+    expect(process.listenerCount("SIGTERM")).toBe(sigtermListeners);
+  });
+
+  it.each([
+    { args: ["--json"], label: "JSON output" },
+    { args: ["--format", "json"], label: "explicit JSON output" },
+    { args: ["--format=json"], label: "inline JSON output" },
+    { args: ["--no-interactive"], label: "non-interactive output" },
+    { args: [], ci: "1", label: "CI output" },
+    { args: [], label: "non-TTY stderr", stderrIsTTY: false },
+    { args: [], label: "dumb terminal", term: "dumb" },
+  ])("suppresses UI-check progress for $label", async ({
+    args,
+    ci,
+    stderrIsTTY,
+    term,
+  }) => {
+    const output = await captureUiCheckStreams({
+      args,
+      ci,
+      stderrIsTTY,
+      term,
+    });
+
+    expect(output.failure).toBeUndefined();
+    expect(output.stderr).toBe("");
+    expect(output.stdout).not.toBe("");
+    for (const label of UI_CHECK_PROGRESS_PHASE_LABELS) {
+      expect(output.stderr).not.toContain(label);
+    }
+  });
+
+  it("keeps UI-check progress on stderr when stdout is redirected", async () => {
+    const output = await captureUiCheckStreams({ stdoutIsTTY: false });
+
+    expect(output.failure).toBeUndefined();
+    for (const label of UI_CHECK_PROGRESS_PHASE_LABELS) {
+      expect(output.stderr).toContain(label);
+      expect(output.stdout).not.toContain(label);
+    }
+    expect(output.stdout).toContain("PASS");
+  });
+
+  it("shows UI-check progress for explicit human output", async () => {
+    const output = await captureUiCheckStreams({
+      args: ["--format", "human"],
+    });
+
+    expect(output.failure).toBeUndefined();
+    for (const label of UI_CHECK_PROGRESS_PHASE_LABELS) {
+      expect(output.stderr).toContain(label);
+    }
+  });
+
+  it("keeps UI-check progress identical through the hidden legacy alias", async () => {
+    const primary = await captureUiCheckStreams({ uiFlag: "--check-ui" });
+    const legacy = await captureUiCheckStreams({ uiFlag: "--check-overflow" });
+
+    expect(primary.failure).toBeUndefined();
+    expect(legacy).toEqual(primary);
   });
 
   it("uses --check-ui as the primary rendered UI command", async () => {

--- a/test/e2e/docs-page.spec.ts
+++ b/test/e2e/docs-page.spec.ts
@@ -191,6 +191,7 @@ test("documents the CLI before the optional agent workflow", async ({
   await expect(uiCheck).toContainText("Checking mobile and desktop layouts");
   await expect(uiCheck).toContainText("Preparing UI report");
   await expect(uiCheck).toContainText("Interactive human runs");
+  await expect(uiCheck).toContainText("TERM=dumb");
   await expect(uiCheck).toContainText("non-TTY stderr");
   await expect(uiCheck).toContainText("--no-interactive");
   await expect(uiCheck).toContainText(

--- a/test/e2e/docs-page.spec.ts
+++ b/test/e2e/docs-page.spec.ts
@@ -167,6 +167,16 @@ test("documents the CLI before the optional agent workflow", async ({
     page.locator("#options dt").getByText("--check-ui <url>", { exact: true })
   ).toBeVisible();
   await expect(
+    page.locator("#options dt").getByText("--no-interactive", { exact: true })
+  ).toBeVisible();
+  await expect(
+    page
+      .locator("#options dd")
+      .getByText("Disable terminal progress and follow-up prompts.", {
+        exact: true,
+      })
+  ).toBeVisible();
+  await expect(
     page.getByRole("link", { exact: true, name: "UI checks" })
   ).toHaveAttribute("href", "#ui-check");
   await expect(page.getByText("production-polish")).toBeVisible();
@@ -177,6 +187,12 @@ test("documents the CLI before the optional agent workflow", async ({
   );
   await expect(uiCheck).toContainText("Mobile: 320 × 820");
   await expect(uiCheck).toContainText("Desktop: 1440 × 1000");
+  await expect(uiCheck).toContainText("Resolving UI target");
+  await expect(uiCheck).toContainText("Checking mobile and desktop layouts");
+  await expect(uiCheck).toContainText("Preparing UI report");
+  await expect(uiCheck).toContainText("Interactive human runs");
+  await expect(uiCheck).toContainText("non-TTY stderr");
+  await expect(uiCheck).toContainText("--no-interactive");
   await expect(uiCheck).toContainText(
     "rendered UI suite, not another source-audit rule"
   );


### PR DESCRIPTION
## Summary

- reuse Shadscan's existing terminal progress renderer for --check-ui
- show Resolving UI target, Checking mobile and desktop layouts, and Preparing UI report on interactive human stderr
- keep JSON, CI, non-TTY, TERM=dumb, and --no-interactive runs quiet
- document the progress lifecycle and preserve identical behavior for the hidden --check-overflow alias

## Verification

- pnpm check
- pnpm docs:check
- pnpm --filter ./packages/cli typecheck
- pnpm cli:test (770 tests)
- focused Playwright suite (18 tests)
- pnpm audit:self (100/100 A)
- pnpm build
- pnpm cli:smoke
- final Shadscan audit (100/100 A, complete coverage, zero warnings)

Standards, Spec, and adversarial reviews completed without actionable findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal progress updates for interactive UI checks, covering target resolution, browser checks, and report preparation.
  * Progress appears only in eligible interactive human terminal sessions and is written to stderr.
  * `--no-interactive` now suppresses both progress updates and follow-up prompts.

* **Documentation**
  * Clarified progress, output, and suppression behavior across CLI documentation.
  * Documented UI-check stages and roast output behavior for CI and JSON modes.

* **Tests**
  * Expanded coverage for progress timing, formatting, failure handling, output modes, and aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->