### PR TITLE
feat(cli): add project-level ignore globs for generated source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ stable releases published under `latest`.
 
 ## Unreleased
 
+### Added
+
+- Source audits now accept extra ignore globs from `--ignore`,
+  `shadscan.config.jsonc`, `shadscan.config.json`, or `package.json#shadscan`.
+  They merge with the built-in exclusions, apply at source discovery, and
+  appear on the report as `coverage.ignorePatterns` (`schemaVersion` 10).
+
 ## 0.16.0 - 2026-08-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ pnpm dlx @shadscan/cli@0.16.0 --fail-under 80 --no-interactive --no-roast
 # Audit one category while investigating a focused area
 pnpm dlx @shadscan/cli --category accessibility
 
+# Skip generated API clients that are not UI source
+pnpm dlx @shadscan/cli --ignore "src/api/**"
+
 # See which workspace packages shadscan found, without scanning
 pnpm dlx @shadscan/cli --list-projects
 
@@ -142,6 +145,13 @@ Use `--format human`, `--format json`, or `--format prompt` when output selectio
 needs to be explicit. Pin an exact package version in CI; unqualified commands
 resolve to the latest stable release. Run `pnpm dlx @shadscan/cli --help` for
 every option.
+
+Generated API clients and other non-UI trees can be excluded with repeatable
+`--ignore` globs, or with an `ignore` array in `shadscan.config.jsonc`,
+`shadscan.config.json`, or `package.json#shadscan`. Extra patterns merge with
+the built-in skips (`node_modules`, `dist`, `**/generated/**`, and similar).
+They cannot re-include those paths. JSON reports list the extra patterns on
+`coverage.ignorePatterns`.
 
 ## Check Rendered UI
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -13,6 +13,11 @@ shadscan --check-ui <url> [--route <path> ...]
 
 - `path` selects the React project to scan and defaults to the current working
   directory.
+- Repeatable `--ignore <glob>` values exclude matching source paths from the
+  audit. They merge with built-in ignores and with `ignore` from
+  `shadscan.config.jsonc`, `shadscan.config.json`, or `package.json#shadscan`
+  in the scanned package. Negation globs and absolute or parent paths are
+  rejected. `--category` and `--project` remain orthogonal filters.
 - Relative paths resolve from the invoking process's working directory.
 - Supported adapters are Next.js App Router, Next.js Pages Router, hybrid Next.js
   projects containing both router trees, Vite React, and generic React projects.
@@ -63,6 +68,8 @@ shadscan --check-ui <url> [--route <path> ...]
   a deterministic ASCII bar with color disabled by default. `NO_COLOR` always
   wins, while `FORCE_COLOR` can explicitly color the ASCII fallback.
 - `--format json` and `--json` write one versioned JSON report to stdout.
+  `coverage.ignorePatterns` lists the extra user ignore globs that were
+  applied, or an empty array when none were configured.
 - `--format prompt` and `--prompt` write one deterministic agent handoff to
   stdout.
 - Rendered UI mode supports human output, `--format human`, `--format json`,

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -93,7 +93,7 @@ A real filtered response, trimmed to one actionable:
 {
   "engineVersion": "0.8.0",
   "rulesetVersion": "2026.07.41",
-  "schemaVersion": 9,
+  "schemaVersion": 10,
   "actionables": [
     {
       "findingId": "theme-provider-configured",

--- a/lib/shadscan-api/openapi.ts
+++ b/lib/shadscan-api/openapi.ts
@@ -615,8 +615,12 @@ const OPENAPI_DOCUMENT = {
           coverage: {
             type: "object",
             additionalProperties: false,
-            required: ["source"],
+            required: ["ignorePatterns", "source"],
             properties: {
+              ignorePatterns: {
+                items: { type: "string" },
+                type: "array",
+              },
               source: {
                 enum: ["complete", "partial"],
                 type: "string",

--- a/lib/shadscan-api/protocol.ts
+++ b/lib/shadscan-api/protocol.ts
@@ -14,7 +14,7 @@ const JSON_MEDIA_TYPE = "application/json";
 
 const PUBLIC_CONTRACT_VERSIONS = {
   prompt: 5,
-  report: 9,
+  report: 10,
   scan: HOSTED_SCAN_SCHEMA_VERSION,
 } as const;
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -123,6 +123,9 @@ pnpm exec shadscan --fail-under 80 --no-interactive --no-roast
 # Audit one category while investigating a focused area
 pnpm dlx @shadscan/cli --category accessibility
 
+# Skip generated API clients that are not UI source
+pnpm dlx @shadscan/cli --ignore "src/api/**"
+
 # Run rendered UI checks against an already-running app
 pnpm dlx @shadscan/cli --check-ui http://localhost:3000
 

--- a/packages/cli/src/audit.ts
+++ b/packages/cli/src/audit.ts
@@ -20,10 +20,11 @@ const AUDIT_CATEGORIES = [
   "production-polish",
 ] as const;
 
-const AUDIT_REPORT_SCHEMA_VERSION = 9 as const;
+const AUDIT_REPORT_SCHEMA_VERSION = 10 as const;
 const ENGINE_VERSION = packageJson.version;
 const CUSTOM_RULESET_VERSION = "custom";
 const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[a-zA-Z]:[\\/]/;
+const SHELL_UNSAFE_IGNORE_PATTERN = /[\s"'\\]/;
 
 const CATEGORY_DETAILS = {
   accessibility: {
@@ -209,6 +210,7 @@ interface AuditReport {
   agentHandoff: AgentHandoff;
   categories: AuditCategoryScore[];
   coverage: {
+    ignorePatterns: string[];
     source: ProjectDiscovery["sourceCoverage"];
   };
   durationMs: number;
@@ -240,6 +242,7 @@ interface AuditReport {
 interface RunAuditOptions {
   category?: AuditCategory;
   filesystemRoot?: string;
+  ignorePatterns?: readonly string[];
   rules: AuditRule[];
   rulesetVersion?: string;
   signal?: AbortSignal;
@@ -370,6 +373,7 @@ const AuditReportSchema = z.object({
     })
   ),
   coverage: z.object({
+    ignorePatterns: z.array(z.string()),
     source: z.enum(["complete", "partial"]),
   }),
   durationMs: z.number(),
@@ -904,8 +908,15 @@ const getShadscanCommand = (
   const categoryOption = category ? ` --category ${category}` : "";
   const projectArgument = getSelectedProjectArgument(project);
   const projectOption = projectArgument ? ` ${projectArgument}` : "";
+  const ignoreOptions = project.ignorePatterns
+    .map((pattern) =>
+      SHELL_UNSAFE_IGNORE_PATTERN.test(pattern)
+        ? ` --ignore ${JSON.stringify(pattern)}`
+        : ` --ignore ${pattern}`
+    )
+    .join("");
   const packageSpecifier = `@shadscan/cli@${ENGINE_VERSION}`;
-  return `${executor(packageSpecifier)}${projectOption} --json${categoryOption}`;
+  return `${executor(packageSpecifier)}${projectOption} --json${categoryOption}${ignoreOptions}`;
 };
 
 const uniqueEvidence = (actionables: AgentActionable[]): AuditEvidence[] => {
@@ -1282,6 +1293,9 @@ const createAgentHandoff = ({
       `Package manager: ${project.packageManager}`,
       `Selected project directory: ${project.selectedProjectPath} (relative to the package-manager root)`,
       `Source coverage: ${project.sourceCoverage}`,
+      project.ignorePatterns.length > 0
+        ? `Extra ignore patterns: ${project.ignorePatterns.join(", ")}`
+        : "Extra ignore patterns: none",
       `shadcn confidence: ${project.shadcn.confidence}; config: ${configPath}`,
       `Warnings: ${warnings}`,
     ],
@@ -1333,6 +1347,7 @@ const createAuditReport = ({
     }),
     categories,
     coverage: {
+      ignorePatterns: project.ignorePatterns,
       source: project.sourceCoverage,
     },
     durationMs,
@@ -1374,6 +1389,7 @@ const runAudit = async (
   options.signal?.throwIfAborted();
   const project = await discoverProject(cwd, {
     filesystemRoot: options.filesystemRoot,
+    ignorePatterns: options.ignorePatterns,
   });
   options.signal?.throwIfAborted();
   const context: AuditContext = {

--- a/packages/cli/src/cli-error.ts
+++ b/packages/cli/src/cli-error.ts
@@ -9,6 +9,7 @@ import {
   type OverflowCheckErrorCode,
 } from "./overflow-check/error";
 import { PreCommitError, type PreCommitErrorCode } from "./pre-commit";
+import { ScanConfigError } from "./scan-ignores";
 
 const COMMANDER_ERROR_PREFIX_PATTERN = /^error:\s*/i;
 
@@ -20,7 +21,8 @@ interface CliFailure {
     | AgentCliErrorCode
     | OverflowCheckErrorCode
     | PreCommitErrorCode
-    | ProjectDiscoveryErrorCode;
+    | ProjectDiscoveryErrorCode
+    | "INVALID_SCAN_CONFIG";
   message: string;
 }
 
@@ -33,6 +35,13 @@ const normalizeCliFailure = (error: unknown): CliFailure => {
   }
 
   if (error instanceof AgentCliError || error instanceof PreCommitError) {
+    return {
+      code: error.code,
+      message: error.message,
+    };
+  }
+
+  if (error instanceof ScanConfigError) {
     return {
       code: error.code,
       message: error.message,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -72,6 +72,7 @@ interface CliOptions {
   checkUi?: string;
   failUnder?: number;
   format?: OutputFormat;
+  ignore?: string[];
   interactive: boolean;
   json?: boolean;
   listProjects?: boolean;
@@ -125,6 +126,15 @@ const parseAgent = (value: string): AgentId => {
   } catch {
     throw new InvalidArgumentError("Expected one of: claude, codex, grok.");
   }
+};
+
+const collectIgnore = (value: string, patterns: string[] = []): string[] => {
+  if (value.trim().length === 0) {
+    throw new InvalidArgumentError("Expected a non-empty ignore glob.");
+  }
+
+  patterns.push(value);
+  return patterns;
 };
 
 const collectRoute = (value: string, routes: string[] = []): string[] => {
@@ -525,6 +535,7 @@ const validateUiModeOptions = ({
     options.prompt || outputFormat === "prompt" ? "--prompt" : null,
     options.listProjects ? "--list-projects" : null,
     options.project ? "--project" : null,
+    (options.ignore?.length ?? 0) > 0 ? "--ignore" : null,
     command.getOptionValueSource("roast") === "cli" && options.roast === true
       ? "--roast"
       : null,
@@ -736,10 +747,12 @@ const renderScanOutput = ({
 
 const runProjectScanPhases = async ({
   category,
+  ignorePatterns,
   progress,
   projectPath,
 }: {
   category?: AuditCategory;
+  ignorePatterns?: readonly string[];
   progress: ScanProgress;
   projectPath: string;
 }): Promise<{ project: ProjectDiscovery; report: AuditReport }> => {
@@ -747,10 +760,10 @@ const runProjectScanPhases = async ({
     resolveProjectPath(projectPath)
   );
   const project = await progress.run("Discovering app structure", () =>
-    discoverProject(resolvedProjectPath)
+    discoverProject(resolvedProjectPath, { ignorePatterns })
   );
   const report = await progress.run("Evaluating UI rules", () =>
-    scanProject(project.rootDir, { category })
+    scanProject(project.rootDir, { category, ignorePatterns })
   );
 
   return { project, report };
@@ -838,15 +851,21 @@ const runScanAction = async (
 
       return {
         kind: "project" as const,
-        project: await discoverProject(selectedPath),
+        project: await discoverProject(selectedPath, {
+          ignorePatterns: options.ignore,
+        }),
       };
     }
   );
   const report = await progress.run("Evaluating UI rules", () =>
     scanTarget.kind === "workspace"
-      ? scanWorkspace(scanTarget.rootDir, { category: options.category })
+      ? scanWorkspace(scanTarget.rootDir, {
+          category: options.category,
+          ignorePatterns: options.ignore,
+        })
       : scanProject(scanTarget.project.rootDir, {
           category: options.category,
+          ignorePatterns: options.ignore,
         })
   );
   const output = await progress.run("Preparing report", () =>
@@ -1010,6 +1029,11 @@ const createProgram = (runtime: UiCheckRuntime = {}): Command => {
     .option(
       "--no-interactive",
       "Disable terminal progress and follow-up prompts."
+    )
+    .option(
+      "--ignore <glob>",
+      "Exclude matching source paths from the audit (repeatable).",
+      collectIgnore
     )
     .option(
       "--list-projects",

--- a/packages/cli/src/component-render-graph/astro-surface-planning.ts
+++ b/packages/cli/src/component-render-graph/astro-surface-planning.ts
@@ -5,7 +5,7 @@ import {
   templateRendersTag,
 } from "../astro-frontmatter";
 import { compareCodeUnits } from "../deterministic-order";
-import { findFiles, getProjectSourceFiles } from "../rules/source-files";
+import { findProjectFiles, getProjectSourceFiles } from "../rules/source-files";
 import { addSurfacePlan } from "./surface-plan-budget";
 import { getRecordDefault, getRecordNamed } from "./symbol-resolution";
 import type {
@@ -139,7 +139,7 @@ const addAstroSurfacePlans = async (
     .sort((left, right) => compareCodeUnits(left.path, right.path));
   // Markdown pages are routes too, but carry no React surface; they are not
   // part of the scanned source set, so they are globbed directly.
-  const mdxPages = await findFiles(state.project.rootDir, [
+  const mdxPages = await findProjectFiles(state.project, [
     "src/pages/**/*.{md,mdx}",
   ]);
 

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -2,6 +2,7 @@ import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { type ParseError, parse } from "jsonc-parser";
 import { glob } from "tinyglobby";
+import { resolveProjectIgnorePatterns } from "./scan-ignores";
 
 type JsonObject = Record<string, unknown>;
 
@@ -23,6 +24,7 @@ type SourceCoverage = "complete" | "partial";
 
 interface DiscoverProjectOptions {
   filesystemRoot?: string;
+  ignorePatterns?: readonly string[];
 }
 
 interface FrameworkDiscovery {
@@ -69,6 +71,8 @@ interface ProjectVersions {
 interface ProjectDiscovery {
   dependencies: Record<string, string>;
   framework: FrameworkDiscovery;
+  /** Extra user ignore globs merged on top of the built-in source ignores. */
+  ignorePatterns: string[];
   packageManager: PackageManager;
   packageManagerRoot: string;
   packageName: string | null;
@@ -807,10 +811,15 @@ const discoverProject = async (
       .relative(packageManagerDiscovery.rootDir, rootDir)
       .split(path.sep)
       .join("/") || ".";
+  const ignorePatterns = await resolveProjectIgnorePatterns({
+    cliIgnorePatterns: options.ignorePatterns,
+    rootDir,
+  });
 
   return {
     dependencies,
     framework,
+    ignorePatterns,
     packageManager: packageManagerDiscovery.packageManager,
     packageManagerRoot: packageManagerDiscovery.rootDir,
     packageName,

--- a/packages/cli/src/render-human.ts
+++ b/packages/cli/src/render-human.ts
@@ -435,6 +435,11 @@ const renderHumanReport = (
     report.workspace
       ? `Packages: ${report.workspace.projects.length} discovered`
       : `Package: ${sanitizeTerminalText(report.packageName ?? "unknown")}`,
+    ...(report.coverage.ignorePatterns.length > 0
+      ? [
+          `Ignoring: ${report.coverage.ignorePatterns.map(sanitizeTerminalText).join(", ")}`,
+        ]
+      : []),
     "",
     "Categories:",
     ...renderCategories(report),

--- a/packages/cli/src/rules/error-state-retry-present.ts
+++ b/packages/cli/src/rules/error-state-retry-present.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { AuditRule } from "../audit";
 import { fail, notApplicable, pass } from "./rule-result";
-import { findFiles, getTextLineNumber } from "./source-files";
+import { findProjectFiles, getTextLineNumber } from "./source-files";
 
 const RETRY_CALLBACK_PATTERN =
   /\b(?:unstable_retry|resetErrorBoundary|reset|onRetry|retry)\b/;
@@ -41,8 +41,8 @@ const errorStateRetryPresentRule: AuditRule = {
   id: "error-state-retry-present",
   maxScore: 4,
   run: async ({ project }) => {
-    const errorFiles = await findFiles(
-      project.rootDir,
+    const errorFiles = await findProjectFiles(
+      project,
       getErrorFilePatterns(project.rootDir, project.paths.appDir)
     );
 

--- a/packages/cli/src/rules/high-confidence.ts
+++ b/packages/cli/src/rules/high-confidence.ts
@@ -45,7 +45,7 @@ import {
 } from "./react-router-modules";
 import {
   fileExists,
-  findFiles,
+  findProjectFiles,
   findSourceMatch,
   getAppRelativePatterns,
   getProjectSourceFiles,
@@ -347,10 +347,10 @@ const findFirstSourceMatch = async (
   findSourceMatch(context.project, pattern);
 
 const hasAnyFile = async (
-  rootDir: string,
+  project: ProjectDiscovery,
   patterns: string[]
 ): Promise<string | null> => {
-  const matches = await findFiles(rootDir, patterns, 4);
+  const matches = await findProjectFiles(project, patterns, 4);
 
   return matches[0] ?? null;
 };
@@ -617,7 +617,7 @@ const evaluateReactRouterNotFound = async (
 ): Promise<AuditRuleResult> => {
   const appDir = context.project.paths.reactRouterAppDir;
   const splatRoute = appDir
-    ? await hasAnyFile(context.project.rootDir, [
+    ? await hasAnyFile(context.project, [
         "app/routes/$.{js,jsx,ts,tsx}",
         "app/routes/**/$.{js,jsx,ts,tsx}",
       ])
@@ -799,7 +799,7 @@ const faviconPresentRule: AuditRule = {
   maxScore: 2,
   run: async (context) => {
     const rootDir = context.project.rootDir;
-    const filePath = await hasAnyFile(rootDir, [
+    const filePath = await hasAnyFile(context.project, [
       "app/favicon.ico",
       "app/icon.*",
       "src/app/favicon.ico",
@@ -889,7 +889,7 @@ const faviconPresentRule: AuditRule = {
 const evaluateAstroNotFoundPage = async (
   context: AuditContext
 ): Promise<AuditRuleResult> => {
-  const astroNotFound = await hasAnyFile(context.project.rootDir, [
+  const astroNotFound = await hasAnyFile(context.project, [
     "src/pages/404.{astro,md,mdx}",
   ]);
 
@@ -931,7 +931,7 @@ const notFoundRoutePresentRule: AuditRule = {
     }
 
     if (context.project.versions.inertia && context.project.versions.laravel) {
-      const errorSurface = await hasAnyFile(context.project.rootDir, [
+      const errorSurface = await hasAnyFile(context.project, [
         "resources/views/errors/404.blade.php",
         "resources/js/pages/{error,Error}*.{jsx,tsx}",
         "resources/js/Pages/{error,Error}*.{jsx,tsx}",
@@ -953,7 +953,7 @@ const notFoundRoutePresentRule: AuditRule = {
 
     if (context.project.versions.next && context.project.paths.appDir) {
       const appNotFound = await hasAnyFile(
-        context.project.rootDir,
+        context.project,
         getAppRelativePatterns(context, "not-found.{js,jsx,ts,tsx}")
       );
 
@@ -968,7 +968,7 @@ const notFoundRoutePresentRule: AuditRule = {
     }
 
     if (context.project.versions.next && context.project.paths.pagesDir) {
-      const pagesNotFound = await hasAnyFile(context.project.rootDir, [
+      const pagesNotFound = await hasAnyFile(context.project, [
         "pages/404.{js,jsx,ts,tsx}",
         "src/pages/404.{js,jsx,ts,tsx}",
       ]);
@@ -1034,7 +1034,7 @@ const errorBoundaryPresentRule: AuditRule = {
 
     if (context.project.versions.next && context.project.paths.appDir) {
       const appError = await hasAnyFile(
-        context.project.rootDir,
+        context.project,
         getAppRelativePatterns(context, "error.{js,jsx,ts,tsx}")
       );
 
@@ -1046,7 +1046,7 @@ const errorBoundaryPresentRule: AuditRule = {
     }
 
     if (context.project.versions.next && context.project.paths.pagesDir) {
-      const pagesError = await hasAnyFile(context.project.rootDir, [
+      const pagesError = await hasAnyFile(context.project, [
         "pages/_error.{js,jsx,ts,tsx}",
         "src/pages/_error.{js,jsx,ts,tsx}",
       ]);

--- a/packages/cli/src/rules/not-found-recovery-present.ts
+++ b/packages/cli/src/rules/not-found-recovery-present.ts
@@ -22,7 +22,7 @@ import {
   createConfinedTypeScriptHost,
 } from "../typescript-host";
 import { fail, notApplicable, pass } from "./rule-result";
-import { findFiles, getTextLineNumber } from "./source-files";
+import { findProjectFiles, getTextLineNumber } from "./source-files";
 
 const RECOVERY_CONTROL_PATTERN =
   /<(?:a|Link)\b[^>]*href=|<(?:button|Button)\b[^>]*onClick\s*=\s*\{[^}]*(?:back|push|replace)|<(?:form|Search|SearchInput)(?:\s|>)/i;
@@ -220,7 +220,7 @@ const notFoundRecoveryPresentRule: AuditRule = {
       return notApplicable("No supported Next route directory was found.");
     }
 
-    const notFoundFiles = await findFiles(project.rootDir, patterns);
+    const notFoundFiles = await findProjectFiles(project, patterns);
 
     if (notFoundFiles.length === 0) {
       return notApplicable("No Next not-found UI file was found.");

--- a/packages/cli/src/rules/public-app-seo-files-present.ts
+++ b/packages/cli/src/rules/public-app-seo-files-present.ts
@@ -1,6 +1,6 @@
 import type { AuditRule } from "../audit";
 import { fail, notApplicable, pass } from "./rule-result";
-import { findFiles, getProjectSourceFiles } from "./source-files";
+import { findProjectFiles, getProjectSourceFiles } from "./source-files";
 
 const PRIVATE_INDEXING_PATTERN =
   /\bnoindex\b|\bindex\s*:\s*false\b|Disallow\s*:\s*\/(?:\s|$)/i;
@@ -44,8 +44,8 @@ const publicAppSeoFilesPresentRule: AuditRule = {
       );
     }
 
-    const robotsFiles = await findFiles(project.rootDir, ROBOTS_PATTERNS);
-    const sitemapFiles = await findFiles(project.rootDir, SITEMAP_PATTERNS);
+    const robotsFiles = await findProjectFiles(project, ROBOTS_PATTERNS);
+    const sitemapFiles = await findProjectFiles(project, SITEMAP_PATTERNS);
     const missingFiles: string[] = [];
 
     if (robotsFiles.length === 0) {

--- a/packages/cli/src/rules/route-loading-boundary-present.ts
+++ b/packages/cli/src/rules/route-loading-boundary-present.ts
@@ -36,7 +36,7 @@ import {
 import { fail, notApplicable, pass } from "./rule-result";
 import {
   fileExists,
-  findFiles,
+  findProjectFiles,
   findSourceMatch,
   getProjectSourceFiles,
   getTextLineNumber,
@@ -364,7 +364,7 @@ const runTanstackStartCheck = async (
 
   const relativeRoutesDir = path.relative(project.rootDir, routesDir);
   const routePaths = (
-    await findFiles(project.rootDir, [
+    await findProjectFiles(project, [
       path.join(relativeRoutesDir, "**/*.{js,jsx,ts,tsx}"),
       path.join(relativeRoutesDir, "*.{js,jsx,ts,tsx}"),
     ])
@@ -573,7 +573,7 @@ const routeLoadingBoundaryPresentRule: AuditRule = {
 
     const relativeAppDir = path.relative(project.rootDir, appDir);
     const pagePaths = (
-      await findFiles(project.rootDir, [
+      await findProjectFiles(project, [
         path.join(relativeAppDir, "**/page.{js,jsx,ts,tsx}"),
         path.join(relativeAppDir, "page.{js,jsx,ts,tsx}"),
       ])

--- a/packages/cli/src/rules/social-preview-present.ts
+++ b/packages/cli/src/rules/social-preview-present.ts
@@ -4,7 +4,7 @@ import type { ProjectDiscovery } from "../discovery";
 import { getAstroSourceFiles } from "./astro-mounts";
 import { fail, notApplicable, pass } from "./rule-result";
 import {
-  findFiles,
+  findProjectFiles,
   getProjectSourceFiles,
   getTextLineNumber,
   readProjectSourceFile,
@@ -24,7 +24,7 @@ const TANSTACK_SOCIAL_CONTENT_PATTERN = /\bcontent\s*:\s*["'`][^"'`]+["'`]/;
 const evaluateAppRouterSocialPreview = async (
   project: ProjectDiscovery
 ): Promise<AuditRuleResult> => {
-  const socialImageFiles = await findFiles(project.rootDir, [
+  const socialImageFiles = await findProjectFiles(project, [
     "app/**/opengraph-image.*",
     "app/**/twitter-image.*",
     "src/app/**/opengraph-image.*",

--- a/packages/cli/src/rules/source-files.ts
+++ b/packages/cli/src/rules/source-files.ts
@@ -4,6 +4,7 @@ import { glob } from "tinyglobby";
 import type { AuditContext } from "../audit";
 import { compareCodeUnits } from "../deterministic-order";
 import type { ProjectDiscovery } from "../discovery";
+import { getAppliedIgnorePatterns } from "../scan-ignores";
 import { SCAN_SOURCE_LIMITS } from "../source-requirements";
 
 interface SourceFile {
@@ -49,23 +50,6 @@ const APP_NON_PAGE_SOURCE_PATTERN =
   /(?:^|[/\\])(?:src[/\\])?app[/\\](?:.*[/\\])?(?:apple-icon|icon|opengraph-image|route|twitter-image)\.[cm]?[jt]sx?$/i;
 const PAGES_API_SOURCE_PATTERN =
   /(?:^|[/\\])(?:src[/\\])?pages[/\\]api[/\\].+\.[cm]?[jt]sx?$/i;
-const PROJECT_IGNORES = [
-  "**/.astro/**",
-  "**/.next/**",
-  "**/__fixtures__/**",
-  "**/__mocks__/**",
-  "**/__tests__/**",
-  "**/coverage/**",
-  "**/dist/**",
-  "**/fixtures/**",
-  "**/generated/**",
-  "**/node_modules/**",
-  "**/routeTree.gen.ts",
-  "**/vendor/**",
-  "**/*.{spec,test}.{js,jsx,ts,tsx}",
-  "**/*.stories.{js,jsx,ts,tsx}",
-  "**/*.generated.{js,jsx,ts,tsx}",
-];
 const MAX_PROJECT_FILES = SCAN_SOURCE_LIMITS.maxFiles;
 const MAX_SOURCE_FILE_BYTES = SCAN_SOURCE_LIMITS.maxFileBytes;
 const MAX_TOTAL_SOURCE_BYTES = SCAN_SOURCE_LIMITS.maxTotalBytes;
@@ -129,14 +113,20 @@ const resolveSafeFile = async (
 const findSafeFiles = async (
   rootDir: string,
   patterns: string[],
-  deep?: number
+  {
+    deep,
+    ignorePatterns = [],
+  }: {
+    deep?: number;
+    ignorePatterns?: readonly string[];
+  } = {}
 ): Promise<SafeFileSearch> => {
   const candidates = await glob(patterns, {
     absolute: true,
     cwd: rootDir,
     deep,
     followSymbolicLinks: false,
-    ignore: PROJECT_IGNORES,
+    ignore: getAppliedIgnorePatterns(ignorePatterns),
     onlyFiles: true,
   });
   const files: SafeFile[] = [];
@@ -192,7 +182,9 @@ const loadSourceFiles = async (
   patterns: string[],
   kind: "source" | "style"
 ): Promise<SourceFile[]> => {
-  const search = await findSafeFiles(project.rootDir, patterns);
+  const search = await findSafeFiles(project.rootDir, patterns, {
+    ignorePatterns: project.ignorePatterns,
+  });
   const sourceFiles: SourceFile[] = [];
   let skippedLarge = 0;
   let skippedForBudget = 0;
@@ -316,11 +308,22 @@ const findSourceMatch = async (
 const findFiles = async (
   rootDir: string,
   patterns: string[],
-  deep?: number
+  deep?: number,
+  ignorePatterns: readonly string[] = []
 ): Promise<string[]> => {
-  const search = await findSafeFiles(rootDir, patterns, deep);
+  const search = await findSafeFiles(rootDir, patterns, {
+    deep,
+    ignorePatterns,
+  });
   return search.files.map((file) => file.path);
 };
+
+const findProjectFiles = (
+  project: ProjectDiscovery,
+  patterns: string[],
+  deep?: number
+): Promise<string[]> =>
+  findFiles(project.rootDir, patterns, deep, project.ignorePatterns);
 
 const getAppRelativePatterns = (
   context: AuditContext,
@@ -344,6 +347,7 @@ export type { SourceFile };
 export {
   fileExists,
   findFiles,
+  findProjectFiles,
   findSourceMatch,
   getAppRelativePatterns,
   getProjectSourceFiles,

--- a/packages/cli/src/scan-ignores.ts
+++ b/packages/cli/src/scan-ignores.ts
@@ -1,0 +1,249 @@
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import { type ParseError, parse } from "jsonc-parser";
+import { compareCodeUnits } from "./deterministic-order";
+
+const WINDOWS_ABSOLUTE_PATH_PATTERN = /^[a-zA-Z]:[\\/]/;
+const MAX_USER_IGNORE_PATTERNS = 32;
+const MAX_IGNORE_PATTERN_LENGTH = 256;
+const CONFIG_FILE_NAMES = [
+  "shadscan.config.jsonc",
+  "shadscan.config.json",
+] as const;
+
+/**
+ * Built-in exclusions that always apply. User patterns can only add to this
+ * list; negation globs cannot put `node_modules` or `dist` back in.
+ */
+const BUILTIN_PROJECT_IGNORES = [
+  "**/.astro/**",
+  "**/.next/**",
+  "**/__fixtures__/**",
+  "**/__mocks__/**",
+  "**/__tests__/**",
+  "**/coverage/**",
+  "**/dist/**",
+  "**/fixtures/**",
+  "**/generated/**",
+  "**/node_modules/**",
+  "**/routeTree.gen.ts",
+  "**/vendor/**",
+  "**/*.{spec,test}.{js,jsx,ts,tsx}",
+  "**/*.stories.{js,jsx,ts,tsx}",
+  "**/*.generated.{js,jsx,ts,tsx}",
+] as const;
+
+class ScanConfigError extends Error {
+  readonly code = "INVALID_SCAN_CONFIG" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ScanConfigError";
+  }
+}
+
+const fileExists = async (filePath: string): Promise<boolean> => {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const parseJsoncObject = (content: string, label: string): object => {
+  const errors: ParseError[] = [];
+  const value: unknown = parse(content, errors, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  });
+
+  if (errors.length > 0 || value === undefined) {
+    throw new ScanConfigError(`${label} could not be parsed.`);
+  }
+
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new ScanConfigError(`${label} must be a JSON object.`);
+  }
+
+  return value;
+};
+
+const normalizeIgnorePattern = (value: string, label: string): string => {
+  const pattern = value.trim().replaceAll("\\", "/");
+
+  if (pattern.length === 0) {
+    throw new ScanConfigError(`${label} must not be empty.`);
+  }
+
+  if (pattern.length > MAX_IGNORE_PATTERN_LENGTH) {
+    throw new ScanConfigError(
+      `${label} must be at most ${MAX_IGNORE_PATTERN_LENGTH} characters.`
+    );
+  }
+
+  if (pattern.startsWith("!")) {
+    throw new ScanConfigError(
+      `${label} cannot use a negation glob; built-in ignores always apply.`
+    );
+  }
+
+  if (pattern.startsWith("/") || WINDOWS_ABSOLUTE_PATH_PATTERN.test(pattern)) {
+    throw new ScanConfigError(`${label} must be a project-relative glob.`);
+  }
+
+  if (pattern.split("/").includes("..")) {
+    throw new ScanConfigError(`${label} must not contain parent segments.`);
+  }
+
+  return pattern;
+};
+
+const normalizeIgnorePatterns = (values: unknown, label: string): string[] => {
+  if (!Array.isArray(values)) {
+    throw new ScanConfigError(`${label} must be an array of glob strings.`);
+  }
+
+  if (values.length > MAX_USER_IGNORE_PATTERNS) {
+    throw new ScanConfigError(
+      `${label} is limited to ${MAX_USER_IGNORE_PATTERNS} patterns.`
+    );
+  }
+
+  const patterns = values.map((value, index) => {
+    if (typeof value !== "string") {
+      throw new ScanConfigError(`${label}[${index}] must be a string.`);
+    }
+
+    return normalizeIgnorePattern(value, `${label}[${index}]`);
+  });
+
+  return [...new Set(patterns)].sort(compareCodeUnits);
+};
+
+const readScanConfigIgnores = async (rootDir: string): Promise<string[]> => {
+  const presentConfigFiles: string[] = [];
+
+  for (const fileName of CONFIG_FILE_NAMES) {
+    if (await fileExists(path.join(rootDir, fileName))) {
+      presentConfigFiles.push(fileName);
+    }
+  }
+
+  if (presentConfigFiles.length > 1) {
+    throw new ScanConfigError(
+      "Found both shadscan.config.jsonc and shadscan.config.json; keep only one."
+    );
+  }
+
+  const configFileName = presentConfigFiles[0];
+
+  if (configFileName) {
+    const configPath = path.join(rootDir, configFileName);
+    const config = parseJsoncObject(
+      await readFile(configPath, "utf8"),
+      configFileName
+    );
+    const unknownKeys = Object.keys(config).filter((key) => key !== "ignore");
+
+    if (unknownKeys.length > 0) {
+      throw new ScanConfigError(
+        `${configFileName} only supports an "ignore" array; found ${unknownKeys.sort(compareCodeUnits).join(", ")}.`
+      );
+    }
+
+    if (!("ignore" in config)) {
+      return [];
+    }
+
+    return normalizeIgnorePatterns(config.ignore, `${configFileName} "ignore"`);
+  }
+
+  const packageJsonPath = path.join(rootDir, "package.json");
+
+  if (!(await fileExists(packageJsonPath))) {
+    return [];
+  }
+
+  let packageJson: unknown;
+
+  try {
+    packageJson = JSON.parse(await readFile(packageJsonPath, "utf8"));
+  } catch {
+    return [];
+  }
+
+  if (
+    packageJson === null ||
+    typeof packageJson !== "object" ||
+    Array.isArray(packageJson) ||
+    !("shadscan" in packageJson)
+  ) {
+    return [];
+  }
+
+  const shadscanConfig = packageJson.shadscan;
+
+  if (
+    shadscanConfig === null ||
+    typeof shadscanConfig !== "object" ||
+    Array.isArray(shadscanConfig)
+  ) {
+    throw new ScanConfigError(
+      'package.json "shadscan" must be an object with an optional "ignore" array.'
+    );
+  }
+
+  const unknownKeys = Object.keys(shadscanConfig).filter(
+    (key) => key !== "ignore"
+  );
+
+  if (unknownKeys.length > 0) {
+    throw new ScanConfigError(
+      `package.json "shadscan" only supports an "ignore" array; found ${unknownKeys.sort(compareCodeUnits).join(", ")}.`
+    );
+  }
+
+  if (!("ignore" in shadscanConfig)) {
+    return [];
+  }
+
+  return normalizeIgnorePatterns(
+    shadscanConfig.ignore,
+    'package.json "shadscan.ignore"'
+  );
+};
+
+const mergeIgnorePatterns = (
+  ...groups: readonly (readonly string[])[]
+): string[] => [...new Set(groups.flat())].sort(compareCodeUnits);
+
+const resolveProjectIgnorePatterns = async ({
+  cliIgnorePatterns = [],
+  rootDir,
+}: {
+  cliIgnorePatterns?: readonly string[];
+  rootDir: string;
+}): Promise<string[]> => {
+  const configPatterns = await readScanConfigIgnores(rootDir);
+  const cliPatterns = normalizeIgnorePatterns(
+    [...cliIgnorePatterns],
+    "--ignore"
+  );
+
+  return mergeIgnorePatterns(configPatterns, cliPatterns);
+};
+
+const getAppliedIgnorePatterns = (
+  extraIgnorePatterns: readonly string[]
+): string[] =>
+  mergeIgnorePatterns(BUILTIN_PROJECT_IGNORES, extraIgnorePatterns);
+
+export {
+  BUILTIN_PROJECT_IGNORES,
+  getAppliedIgnorePatterns,
+  mergeIgnorePatterns,
+  normalizeIgnorePatterns,
+  resolveProjectIgnorePatterns,
+  ScanConfigError,
+};

--- a/packages/cli/src/scan-workspace.ts
+++ b/packages/cli/src/scan-workspace.ts
@@ -6,6 +6,7 @@ import {
   type WorkspaceReport,
   type WorkspaceReportProject,
 } from "./audit";
+import { compareCodeUnits } from "./deterministic-order";
 import {
   discoverProject,
   type ProjectDiscovery,
@@ -89,13 +90,15 @@ const toWorkspaceReportProject = (
 const createWorkspaceRootProject = (
   rootDir: string,
   representative: ProjectDiscovery,
-  adapter: PooledAdapter
+  adapter: PooledAdapter,
+  ignorePatterns: string[]
 ): ProjectDiscovery => ({
   ...representative,
   framework: {
     ...representative.framework,
     adapter: adapter as ProjectDiscovery["framework"]["adapter"],
   },
+  ignorePatterns,
   packageName: null,
   rootDir,
   selectedProjectPath: ".",
@@ -165,7 +168,7 @@ const scanWorkspace = async (
     representativeDir === "."
       ? workspace.rootDir
       : path.join(workspace.rootDir, representativeDir),
-    { filesystemRoot }
+    { filesystemRoot, ignorePatterns: options.ignorePatterns }
   );
 
   const workspaceReport: WorkspaceReport = {
@@ -177,6 +180,11 @@ const scanWorkspace = async (
     skipped: workspace.skipped,
     truncated: workspace.truncated,
   };
+  const ignorePatterns = [
+    ...new Set(
+      scanned.flatMap((entry) => entry.report.coverage.ignorePatterns)
+    ),
+  ].sort(compareCodeUnits);
 
   return createAuditReport({
     category: options.category,
@@ -185,7 +193,8 @@ const scanWorkspace = async (
     project: createWorkspaceRootProject(
       workspace.rootDir,
       representative,
-      getPooledAdapter(applications)
+      getPooledAdapter(applications),
+      ignorePatterns
     ),
     rulesetVersion: BUNDLED_RULESET_VERSION,
     source: options.source,

--- a/packages/cli/src/scan.ts
+++ b/packages/cli/src/scan.ts
@@ -5,6 +5,7 @@ import { defaultRules } from "./rules/default-rules";
 interface ScanOptions {
   category?: AuditCategory;
   filesystemRoot?: string;
+  ignorePatterns?: readonly string[];
   signal?: AbortSignal;
   source?: ScanSource;
 }
@@ -18,6 +19,7 @@ const scanProject = async (
   runAudit(rootDir, {
     category: options.category,
     filesystemRoot: options.filesystemRoot,
+    ignorePatterns: options.ignorePatterns,
     rules: defaultRules,
     rulesetVersion: BUNDLED_RULESET_VERSION,
     signal: options.signal,

--- a/packages/cli/test/agent-cli.test.ts
+++ b/packages/cli/test/agent-cli.test.ts
@@ -92,6 +92,7 @@ const createProject = (projectRoot: string): ProjectDiscovery => ({
     adapter: "generic-react",
     evidence: ["react dependency found"],
   },
+  ignorePatterns: [],
   packageManager: "pnpm",
   packageManagerRoot: projectRoot,
   packageName: "agent-fixture",

--- a/packages/cli/test/audit.test.ts
+++ b/packages/cli/test/audit.test.ts
@@ -733,6 +733,7 @@ describe("createAuditReport", () => {
         adapter: "generic-react",
         evidence: [],
       },
+      ignorePatterns: [],
       packageManager: "unknown",
       packageManagerRoot: "/tmp",
       packageName: null,

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -257,6 +257,7 @@ describe("CLI contract", () => {
     expect(help).toContain("Add a same-origin route to --check-ui");
     expect(help).toContain("--browser-executable <path>");
     expect(help).toContain("--check-ui.");
+    expect(help).toContain("--ignore <glob>");
     expect(help).toContain("--no-interactive");
     expect(help).toContain("Disable terminal progress and follow-up prompts.");
     expect(program.commands.map((command) => command.name())).toContain(
@@ -287,6 +288,27 @@ describe("CLI contract", () => {
         ...jsonFormat,
         durationMs: 0,
       });
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("applies --ignore to JSON coverage and source discovery", async () => {
+    const fixture = await createRuleFixture();
+
+    try {
+      await fixture.write(
+        "src/api/hooks/use-session.ts",
+        "export function useAdminDisableSession() { return useMutation(); }\n"
+      );
+      const report = JSON.parse(
+        await captureOutput(
+          ["--json", "--ignore", "src/api/**"],
+          fixture.rootDir
+        )
+      ) as { coverage: { ignorePatterns: string[] } };
+
+      expect(report.coverage.ignorePatterns).toEqual(["src/api/**"]);
     } finally {
       await fixture.cleanup();
     }
@@ -683,6 +705,7 @@ describe("CLI contract", () => {
       { arguments: ["--format", "prompt"], option: "--prompt" },
       { arguments: ["--list-projects"], option: "--list-projects" },
       { arguments: ["--project", "apps/web"], option: "--project" },
+      { arguments: ["--ignore", "src/api/**"], option: "--ignore" },
       { arguments: ["--roast"], option: "--roast" },
     ];
 

--- a/packages/cli/test/render-agent-prompt.test.ts
+++ b/packages/cli/test/render-agent-prompt.test.ts
@@ -16,6 +16,7 @@ const createProject = (): ProjectDiscovery => ({
     adapter: "generic-react",
     evidence: ["react dependency found"],
   },
+  ignorePatterns: [],
   packageManager: "pnpm",
   packageManagerRoot: PROJECT_ROOT,
   packageName: "prompt-fixture",

--- a/packages/cli/test/render-human.test.ts
+++ b/packages/cli/test/render-human.test.ts
@@ -105,6 +105,7 @@ const createReport = (): AuditReport => ({
     },
   ],
   coverage: {
+    ignorePatterns: [],
     source: "complete",
   },
   durationMs: 4,

--- a/packages/cli/test/scan-ignores.test.ts
+++ b/packages/cli/test/scan-ignores.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { AUDIT_REPORT_SCHEMA_VERSION, runAudit } from "../src/audit";
+import { discoverProject } from "../src/discovery";
+import { asyncActionPendingStateRule } from "../src/rules/async-action-pending-state";
+import { getProjectSourceFiles } from "../src/rules/source-files";
+import {
+  resolveProjectIgnorePatterns,
+  ScanConfigError,
+} from "../src/scan-ignores";
+import { createRuleFixture, runRule } from "./rule-fixture";
+
+const fixtures: Array<{ cleanup: () => Promise<void> }> = [];
+
+afterEach(async () => {
+  for (const fixture of fixtures.splice(0)) {
+    await fixture.cleanup();
+  }
+});
+
+const GENERATED_MUTATION = `import { useMutation } from "@tanstack/react-query";
+
+export function useAdminDisableSession() {
+  return useMutation({
+    mutationFn: async () => undefined,
+  });
+}
+`;
+
+const PAGE_WITH_PENDING = `import { useMutation } from "@tanstack/react-query";
+
+export function SessionsPage() {
+  const disableSession = useMutation({
+    mutationFn: async () => undefined,
+  });
+
+  return (
+    <form
+      onSubmit={() => {
+        disableSession.mutate();
+      }}
+    >
+      <button disabled={disableSession.isPending} type="submit">
+        {disableSession.isPending ? <Spinner /> : "Disable"}
+      </button>
+    </form>
+  );
+}
+`;
+
+const PAGE_WITHOUT_PENDING = `import { useMutation } from "@tanstack/react-query";
+
+export function SessionsPage() {
+  const disableSession = useMutation({
+    mutationFn: async () => undefined,
+  });
+
+  return (
+    <form
+      onSubmit={() => {
+        disableSession.mutate();
+      }}
+    >
+      <button type="submit">Disable</button>
+    </form>
+  );
+}
+`;
+
+describe("scan ignore patterns", () => {
+  it("loads extra ignores from shadscan.config.jsonc and CLI flags", async () => {
+    const fixture = await createRuleFixture();
+    fixtures.push(fixture);
+    await fixture.write(
+      "shadscan.config.jsonc",
+      `{
+        // Generated OpenAPI clients
+        "ignore": ["src/api/**"]
+      }\n`
+    );
+
+    await expect(
+      resolveProjectIgnorePatterns({
+        cliIgnorePatterns: ["src/gen/**"],
+        rootDir: fixture.rootDir,
+      })
+    ).resolves.toEqual(["src/api/**", "src/gen/**"]);
+  });
+
+  it("loads extra ignores from package.json when no config file exists", async () => {
+    const fixture = await createRuleFixture();
+    fixtures.push(fixture);
+    await fixture.write(
+      "package.json",
+      `${JSON.stringify(
+        {
+          dependencies: { react: "19.2.4" },
+          name: "expanded-rule-fixture",
+          shadscan: { ignore: ["src/api/**"] },
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    await expect(
+      resolveProjectIgnorePatterns({ rootDir: fixture.rootDir })
+    ).resolves.toEqual(["src/api/**"]);
+  });
+
+  it("rejects negation globs and absolute paths", async () => {
+    const fixture = await createRuleFixture();
+    fixtures.push(fixture);
+
+    await expect(
+      resolveProjectIgnorePatterns({
+        cliIgnorePatterns: ["!**/node_modules/**"],
+        rootDir: fixture.rootDir,
+      })
+    ).rejects.toBeInstanceOf(ScanConfigError);
+
+    await expect(
+      resolveProjectIgnorePatterns({
+        cliIgnorePatterns: ["/tmp/src/**"],
+        rootDir: fixture.rootDir,
+      })
+    ).rejects.toBeInstanceOf(ScanConfigError);
+  });
+
+  it("excludes ignored generated clients from the source index", async () => {
+    const fixture = await createRuleFixture();
+    fixtures.push(fixture);
+    await fixture.write("src/App.tsx", "export const App = () => <main />;\n");
+    await fixture.write("src/api/hooks/use-session.ts", GENERATED_MUTATION);
+    await fixture.write(
+      "shadscan.config.jsonc",
+      `${JSON.stringify({ ignore: ["src/api/**"] })}\n`
+    );
+
+    const project = await discoverProject(fixture.rootDir);
+    const files = await getProjectSourceFiles(project);
+    const relativePaths = files.map((file) =>
+      file.path.slice(fixture.rootDir.length + 1).replaceAll("\\", "/")
+    );
+
+    expect(project.ignorePatterns).toEqual(["src/api/**"]);
+    expect(relativePaths).toContain("src/App.tsx");
+    expect(
+      relativePaths.some((filePath) => filePath.includes("src/api/"))
+    ).toBe(false);
+  });
+
+  it("stops generated mutations from failing pending-state when ignored", async () => {
+    const fixture = await createRuleFixture({
+      "@tanstack/react-query": "5.0.0",
+      react: "19.2.4",
+    });
+    fixtures.push(fixture);
+    await fixture.write("src/sessions-page.tsx", PAGE_WITH_PENDING);
+    await fixture.write("src/api/hooks/use-session.ts", GENERATED_MUTATION);
+
+    expect(
+      (await runRule(fixture.rootDir, asyncActionPendingStateRule)).status
+    ).toBe("fail");
+
+    await fixture.write(
+      "shadscan.config.jsonc",
+      `${JSON.stringify({ ignore: ["src/api/**"] })}\n`
+    );
+
+    expect(
+      (await runRule(fixture.rootDir, asyncActionPendingStateRule)).status
+    ).toBe("pass");
+  });
+
+  it("still fails pending-state when application source omits pending UX", async () => {
+    const fixture = await createRuleFixture({
+      "@tanstack/react-query": "5.0.0",
+      react: "19.2.4",
+    });
+    fixtures.push(fixture);
+    await fixture.write("src/sessions-page.tsx", PAGE_WITHOUT_PENDING);
+    await fixture.write("src/api/hooks/use-session.ts", GENERATED_MUTATION);
+    await fixture.write(
+      "shadscan.config.jsonc",
+      `${JSON.stringify({ ignore: ["src/api/**"] })}\n`
+    );
+
+    expect(
+      (await runRule(fixture.rootDir, asyncActionPendingStateRule)).status
+    ).toBe("fail");
+  });
+
+  it("records extra ignore patterns on the JSON coverage object", async () => {
+    const fixture = await createRuleFixture();
+    fixtures.push(fixture);
+    await fixture.write("src/App.tsx", "export const App = () => <main />;\n");
+
+    const report = await runAudit(fixture.rootDir, {
+      ignorePatterns: ["src/api/**"],
+      rules: [asyncActionPendingStateRule],
+    });
+
+    expect(report.schemaVersion).toBe(AUDIT_REPORT_SCHEMA_VERSION);
+    expect(report.coverage.ignorePatterns).toEqual(["src/api/**"]);
+  });
+});

--- a/packages/cli/test/scan-workspace.test.ts
+++ b/packages/cli/test/scan-workspace.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { AUDIT_REPORT_SCHEMA_VERSION } from "../src/audit";
 import { renderHumanReport } from "../src/render-human";
 import { scanProject } from "../src/scan";
 import { scanWorkspace } from "../src/scan-workspace";
@@ -32,7 +33,7 @@ describe("workspace scanning", () => {
 
     const report = await scanWorkspace(rootDir);
 
-    expect(report.schemaVersion).toBe(9);
+    expect(report.schemaVersion).toBe(AUDIT_REPORT_SCHEMA_VERSION);
     expect(report.workspace?.applicationCount).toBe(2);
     expect(report.score).not.toBeNull();
     expect(getProject(report, "apps/web")?.score).not.toBeNull();

--- a/test/shadscan-api/discovery.test.ts
+++ b/test/shadscan-api/discovery.test.ts
@@ -118,6 +118,10 @@ describe("hosted API OpenAPI document", () => {
       PUBLIC_CONTRACT_VERSIONS.report
     );
     expect(schemas.AuditReport.required).toContain("coverage");
+    expect(schemas.AuditReport.properties.coverage.required).toEqual([
+      "ignorePatterns",
+      "source",
+    ]);
     expect(
       schemas.AuditReport.properties.coverage.properties.source.enum
     ).toEqual(["complete", "partial"]);

--- a/test/shadscan-web/fixtures.ts
+++ b/test/shadscan-web/fixtures.ts
@@ -177,6 +177,7 @@ const WEB_SCAN_COMPLETE_FIXTURE = {
         },
       ],
       coverage: {
+        ignorePatterns: [],
         source: "complete",
       },
       durationMs: 1420,


### PR DESCRIPTION
Allow --ignore and shadscan.config / package.json ignore patterns so codegen paths are excluded from discovery without changing built-in skips.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added repeatable `--ignore <glob>` options for excluding generated or non-UI paths during scans.
  - Added support for configuring ignore patterns in project configuration files.
  - Ignore patterns now apply consistently across project and workspace scans and appear in reports.
  - Human-readable reports display configured exclusions.

- **Bug Fixes**
  - Invalid ignore patterns and conflicting configurations now produce clear scan configuration errors.

- **Documentation**
  - Updated CLI, configuration, reporting, and MCP documentation for ignore patterns and schema version 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->