### PR TITLE
Recognize Base UI toast runtime

### DIFF
--- a/packages/cli/src/rules/high-confidence.ts
+++ b/packages/cli/src/rules/high-confidence.ts
@@ -1109,7 +1109,7 @@ const toastProviderPresentRule: AuditRule = {
     if (!analysis.hasDependency) {
       return fail(
         "No recognized toast runtime dependency was found.",
-        "Install a toast runtime such as Sonner or Radix Toast, then mount its provider from the app shell."
+        "Install a toast runtime such as Base UI Toast, Sonner, or Radix Toast, then mount its provider from the app shell."
       );
     }
 

--- a/packages/cli/src/rules/toast-provider-mounted.ts
+++ b/packages/cli/src/rules/toast-provider-mounted.ts
@@ -20,7 +20,7 @@ const toastProviderMountedRule: AuditRule = {
     if (!analysis.hasDependency) {
       return fail(
         "A toast-like component is mounted without a recognized toast runtime dependency.",
-        "Install a toast runtime such as Sonner or Radix Toast and mount its provider from the app shell.",
+        "Install a toast runtime such as Base UI Toast, Sonner, or Radix Toast and mount its provider from the app shell.",
         { filePath: analysis.shell.path }
       );
     }
@@ -35,7 +35,7 @@ const toastProviderMountedRule: AuditRule = {
 
     return fail(
       "Toast infrastructure with recognized runtime provenance is not mounted from the app shell.",
-      "Render a provider imported from Sonner, Radix Toast, or React Hot Toast in the root shell, directly or through a mounted wrapper.",
+      "Render a provider imported from Base UI Toast, Sonner, Radix Toast, or React Hot Toast in the root shell, directly or through a mounted wrapper.",
       {
         filePath: analysis.shell.path,
         roast:

--- a/packages/cli/src/rules/toast-runtime.ts
+++ b/packages/cli/src/rules/toast-runtime.ts
@@ -63,11 +63,18 @@ interface ParsedProjectFile {
 const MAX_LOCAL_IMPORT_DEPTH = 3;
 const SCRIPT_FILE_PATTERN = /\.[cm]?[jt]sx?$/;
 const TOAST_NAME_PATTERN = /(?:sonner|toast)/i;
-const TOAST_DEPENDENCIES = [
-  "@radix-ui/react-toast",
-  "radix-ui",
-  "react-hot-toast",
-  "sonner",
+const TOAST_RUNTIMES = [
+  {
+    dependencyName: "@base-ui/react",
+    moduleName: "@base-ui/react/toast",
+  },
+  {
+    dependencyName: "@radix-ui/react-toast",
+    moduleName: "@radix-ui/react-toast",
+  },
+  { dependencyName: "radix-ui", moduleName: "radix-ui" },
+  { dependencyName: "react-hot-toast", moduleName: "react-hot-toast" },
+  { dependencyName: "sonner", moduleName: "sonner" },
 ] as const;
 const analysisCache = new WeakMap<
   ProjectDiscovery,
@@ -221,13 +228,21 @@ const isRuntimeImport = (
   referencedIdentifiers: Set<string>,
   project: ProjectDiscovery
 ): boolean => {
-  if (!project.dependencies[reference.moduleName]) {
+  const runtime = TOAST_RUNTIMES.find(
+    (candidate) => candidate.moduleName === reference.moduleName
+  );
+
+  if (!(runtime && project.dependencies[runtime.dependencyName])) {
     return false;
   }
 
   const usedBindings = reference.bindings.filter((binding) =>
     referencedIdentifiers.has(binding.localName)
   );
+
+  if (reference.moduleName === "@base-ui/react/toast") {
+    return usedBindings.some((binding) => binding.importedName === "Toast");
+  }
 
   if (reference.moduleName === "radix-ui") {
     return usedBindings.some((binding) => binding.importedName === "Toast");
@@ -567,8 +582,8 @@ const runToastRuntimeAnalysis = async (
   filesystemRoot: string
 ): Promise<ToastRuntimeAnalysis> => {
   const resolver = getProjectModuleResolver(project, filesystemRoot);
-  const hasDependency = TOAST_DEPENDENCIES.some(
-    (dependency) => project.dependencies[dependency]
+  const hasDependency = TOAST_RUNTIMES.some(
+    (runtime) => project.dependencies[runtime.dependencyName]
   );
   const shells = await readShells(project);
   const firstShell = shells[0] ?? null;

--- a/packages/cli/test/high-confidence-rules.test.ts
+++ b/packages/cli/test/high-confidence-rules.test.ts
@@ -28,7 +28,7 @@ const writeNextPackage = async (
   rootDir: string,
   options: {
     includeToastDependency?: boolean;
-    toastDependency?: "radix-ui" | "sonner";
+    toastDependency?: "@base-ui/react" | "radix-ui" | "sonner";
   } = {}
 ): Promise<void> => {
   const toastDependency =
@@ -524,6 +524,75 @@ describe("high confidence rules", () => {
       report.findings.find((finding) => finding.id === "toast-provider-present")
         ?.status
     ).toBe("pass");
+  });
+
+  it("recognizes a mounted Base UI toast wrapper", async () => {
+    const rootDir = await createFixture();
+    await writeNextPackage(rootDir, { toastDependency: "@base-ui/react" });
+    await writeComponentsJson(rootDir);
+    await writeAliasTsconfig(rootDir);
+    await writeFixtureFile(
+      rootDir,
+      "app/layout.tsx",
+      `
+        import { Toaster } from "@/components/ui/toast";
+        export default function Layout({ children }: { children: React.ReactNode }) {
+          return <html><body>{children}<Toaster /></body></html>;
+        }
+      `
+    );
+    await writeFixtureFile(
+      rootDir,
+      "components/ui/toast.tsx",
+      `
+        import { Toast as ToastPrimitives } from "@base-ui/react/toast";
+        export function Toaster() {
+          return (
+            <ToastPrimitives.Provider>
+              <ToastPrimitives.Portal>
+                <ToastPrimitives.Viewport />
+              </ToastPrimitives.Portal>
+            </ToastPrimitives.Provider>
+          );
+        }
+      `
+    );
+
+    const report = await runAudit(rootDir, {
+      rules: highConfidenceRules,
+    });
+    const finding = report.findings.find(
+      (candidate) => candidate.id === "toast-provider-present"
+    );
+
+    expect(finding?.status).toBe("pass");
+    expect(finding?.evidence[0]?.message).toContain("@base-ui/react/toast");
+  });
+
+  it("rejects unrelated Base UI imports in toast-like wrappers", async () => {
+    const rootDir = await createFixture();
+    await writeNextPackage(rootDir, { toastDependency: "@base-ui/react" });
+    await writeComponentsJson(rootDir);
+    await writeAliasTsconfig(rootDir);
+    await writeFixtureFile(
+      rootDir,
+      "app/layout.tsx",
+      'import { Toaster } from "@/components/toaster"; export default function Layout() { return <html><body><Toaster /></body></html>; }'
+    );
+    await writeFixtureFile(
+      rootDir,
+      "components/toaster.tsx",
+      'import { Button } from "@base-ui/react/button"; export function Toaster() { return <Button>Toast</Button>; }'
+    );
+
+    const report = await runAudit(rootDir, {
+      rules: highConfidenceRules,
+    });
+
+    expect(
+      report.findings.find((finding) => finding.id === "toast-provider-present")
+        ?.status
+    ).toBe("fail");
   });
 
   it("rejects unrelated Radix umbrella imports in toast-like wrappers", async () => {

--- a/packages/cli/test/state-rules.test.ts
+++ b/packages/cli/test/state-rules.test.ts
@@ -576,6 +576,38 @@ describe("state rules", () => {
     }
   });
 
+  it("follows a mounted toaster to Base UI primitives", async () => {
+    const fixture = await createRuleFixture({
+      "@base-ui/react": "1.6.0",
+      next: "16.2.6",
+      react: "19.2.4",
+    });
+
+    try {
+      await fixture.write(
+        "tsconfig.json",
+        JSON.stringify({
+          compilerOptions: { baseUrl: ".", paths: { "@/*": ["./*"] } },
+        })
+      );
+      await fixture.write(
+        "app/layout.tsx",
+        'import { Toaster } from "@/components/ui/toast"; export default function Layout({ children }) { return <html><body>{children}<Toaster /></body></html>; }'
+      );
+      await fixture.write(
+        "components/ui/toast.tsx",
+        'import { Toast } from "@base-ui/react/toast"; export function Toaster() { return <Toast.Provider><Toast.Portal><Toast.Viewport /></Toast.Portal></Toast.Provider>; }'
+      );
+
+      const finding = await runRule(fixture.rootDir, toastProviderMountedRule);
+
+      expect(finding.status).toBe("pass");
+      expect(finding.evidence[0]?.message).toContain("@base-ui/react/toast");
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   it("accepts direct Radix providers and terminates cyclic wrappers", async () => {
     const directFixture = await createRuleFixture({
       "@radix-ui/react-toast": "1.2.0",


### PR DESCRIPTION
## Summary
- recognize @base-ui/react/toast when the installed package is @base-ui/react
- preserve runtime provenance checks so unrelated Base UI subpaths do not satisfy toast rules
- update remediation guidance and cover both toast-provider-present and toast-provider-mounted

## Validation
- pnpm check
- pnpm typecheck
- pnpm cli:test (786 tests)
- pnpm cli:build
- pnpm audit:self (100/100)
- pnpm cli:pack:dry-run
- pnpm build
- pnpm test:api (140 tests)
- pnpm test:web (170 tests)
- pnpm test:e2e (81 tests)
- pre-commit node_modules/.bin/shadscan --json (100/100)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting Base UI Toast as a recognized toast runtime.
  * Updated setup guidance to include Base UI Toast alongside Sonner and Radix Toast.
* **Bug Fixes**
  * Improved validation to recognize Base UI Toast only when the correct toast module and `Toast` binding are used.
* **Tests**
  * Added coverage for valid and invalid Base UI Toast provider configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->